### PR TITLE
Temp fix for netcommon update, pinning to less than 2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ networktocode.nautobot Release Notes
 
 .. contents:: Topics
 
+v1.0.1
+======
+
+Release Summary
+---------------
+
+Pins ansible.netcommon to < 2.0 to use ipaddress function that is removed in 2.0.0
 
 v1.0.0
 ======

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -47,7 +47,7 @@ tags:
 # range specifiers can be set and are separated by ','
 dependencies:
   # Required for ipaddress python library
-  ansible.netcommon: ">=1.0.0"
+  ansible.netcommon: ">=1.0.0,<2.0.0"
 
   # Required for json_query used in lookup plugin integration tests
   community.general: ">=1.0.0"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: networktocode
 name: nautobot
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.0
+version: 1.0.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
- Updates to have a temporary pinning of netcommon library until replacement can be setup
- Updates version
