### PR TITLE
Add missing field description to tenant_groups

### DIFF
--- a/plugins/modules/tenant_group.py
+++ b/plugins/modules/tenant_group.py
@@ -52,6 +52,11 @@ options:
           - URL-friendly unique shorthand
         required: false
         type: str
+      description:
+        description:
+          - The description of the tenant
+        required: false
+        type: str
     required: true
   state:
     description:

--- a/plugins/modules/tenant_group.py
+++ b/plugins/modules/tenant_group.py
@@ -136,6 +136,7 @@ def main():
                 options=dict(
                     name=dict(required=True, type="str"),
                     slug=dict(required=False, type="str"),
+                    description=dict(required=False, type="str"),
                 ),
             ),
         )


### PR DESCRIPTION
Add missing `description` field in modul `tenant_groups`


```
$ ansible --version
ansible 2.9.18
  config file = /home/ansible/devel/develop/nautobot-ansible/ansible.cfg
  configured module search path = ['/home/ansible/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ansible/devel/develop/nornir/lib/python3.7/site-packages/ansible
  executable location = /home/ansible/devel/develop/nornir/bin/ansible
  python version = 3.7.4 (default, Aug 19 2019, 12:50:17) [GCC 4.8.5 20150623 (Red Hat 4.8.5-36)]
```

`nautobot-ansible version: 1.0.4`

`pynautobot==1.0.1`
