### PR TITLE
Updates kwarg for ssl_verify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   global:
     - COLLECTION_NAMESPACE: "networktocode"
     - COLLECTION_NAME: "nautobot"
-    - COLLECTION_VERSION: "2.0.0"
+    - COLLECTION_VERSION: "2.0.1"
 
 jobs:
   include:

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -1306,7 +1306,7 @@ class NautobotApiBase:
     def __init__(self, **kwargs):
         self.url = kwargs.get("url") or os.getenv("NAUTOBOT_URL")
         self.token = kwargs.get("token") or os.getenv("NAUTOBOT_TOKEN")
-        self.ssl_verify = kwargs.get("validate_certs", True)
+        self.ssl_verify = kwargs.get("ssl_verify", True)
 
         # Setup the API client calls
         self.api = pynautobot.api(url=self.url, token=self.token)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot_ansible_modules"
-version = "2.0.0"
+version = "2.0.1"
 description = "Ansible collection to interact with Nautobot's API"
 authors = ["Network to Code <opensource@networktocode.com"]
 license = "Apache 2.0"

--- a/tests/unit/module_utils/test_graphql_utils.py
+++ b/tests/unit/module_utils/test_graphql_utils.py
@@ -15,7 +15,7 @@ except ImportError:
 
 def test_setup_api_base():
     test_class = NautobotApiBase(
-        url="https://nautobot.example.com", token="abc123", validate_certs=False
+        url="https://nautobot.example.com", token="abc123", ssl_verify=False
     )
     assert isinstance(test_class.api, pynautobot.api)
     assert test_class.url == "https://nautobot.example.com"

--- a/tests/unit/module_utils/test_graphql_utils.py
+++ b/tests/unit/module_utils/test_graphql_utils.py
@@ -23,6 +23,16 @@ def test_setup_api_base():
     assert test_class.ssl_verify == False
 
 
+def test_setup_api_base_ssl_verify_true():
+    test_class = NautobotApiBase(
+        url="https://nautobot.example.com", token="abc123", ssl_verify=True
+    )
+    assert isinstance(test_class.api, pynautobot.api)
+    assert test_class.url == "https://nautobot.example.com"
+    assert test_class.token == "abc123"
+    assert test_class.ssl_verify == True
+
+
 def test_query_api_setup(nautobot_api_base, graphql_test_query):
     test_class = NautobotGraphQL(query_str=graphql_test_query, api=nautobot_api_base)
     assert isinstance(test_class, NautobotGraphQL)


### PR DESCRIPTION
## Fixes #44 

- Updates to use `ssl_verify` as kwarg in utils to match the calls to the function
- Updates Version to 2.0.1