### PR TITLE
Fix: Virtual Chassis attach to master - device UUID used, expected name

### DIFF
--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -333,7 +333,7 @@ ALLOWED_QUERY_PARAMS = {
     "termination_a": set(["name", "device", "virtual_machine"]),
     "termination_b": set(["name", "device", "virtual_machine"]),
     "untagged_vlan": set(["group", "name", "site", "vid", "vlan_group", "tenant"]),
-    "virtual_chassis": set(["name", "master"]),
+    "virtual_chassis": set(["name", "device"]),
     "virtual_machine": set(["name", "cluster"]),
     "vlan": set(["group", "name", "site", "tenant", "vid", "vlan_group"]),
     "vlan_group": set(["slug", "site"]),


### PR DESCRIPTION
Fix to attach virtual chassis to device, issue #51
Virtual chassis can now be attached to master device:

Output:
``` yaml
PLAY [Nautobot add devices from inventory] **************************************************************************************************************************************

TASK [NAUTOBOT >> Create devices] ***********************************************************************************************************************************************
ok: [NET-SWI-DIST] => (item=OS6860E-P24)
ok: [NET-SWI-001] => (item=OS6560-P48X4)
ok: [NET-SWI-001] => (item=OS6560-P48X4)
ok: [NET-SWI-001] => (item=OS6560-P48X4)
ok: [NET-SWI-001] => (item=OS6560-P48X4)

TASK [NetBox - Create virtual chassis] ******************************************************************************************************************************************
ok: [NET-SWI-DIST]
ok: [NET-SWI-001]

TASK [NetBox - Add devices to Virtual chassis] **********************************************************************************************************************************
ok: [NET-SWI-DIST] => (item={'type': 'OS6860E-P24', 'unit': 1})
ok: [NET-SWI-001] => (item={'type': 'OS6560-P48X4', 'unit': 1})
ok: [NET-SWI-001] => (item={'type': 'OS6560-P48X4', 'unit': 2})
ok: [NET-SWI-001] => (item={'type': 'OS6560-P48X4', 'unit': 3})
ok: [NET-SWI-001] => (item={'type': 'OS6560-P48X4', 'unit': 4})

TASK [NetBox - Virtual chassis set master] **************************************************************************************************************************************
ok: [NET-SWI-001]
ok: [NET-SWI-DIST]

PLAY RECAP **********************************************************************************************************************************************************************
NET-SWI-001            : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
NET-SWI-DIST           : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```