### PR TITLE
Adds release to on:

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,13 @@
 ---
 name: "CI"
-on:
+on:  # yamllint disable
   push:
     branches:
       - "develop"
       - "main"
   pull_request:
+  release:
+    types: [published]
   schedule:
     - cron: "20 3 * * 1"
 


### PR DESCRIPTION
- The last publish action did not kick off a GitHub action
- This looks to add a `on:` `release` to have the GHA get started