### PR TITLE
Move pass/continue for ID/UUIDs within find_ids

### DIFF
--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -855,6 +855,11 @@ class NautobotModule:
         """
         for k, v in data.items():
             if k in CONVERT_TO_ID:
+                # Do not attempt to resolve if already ID/UUID is provided
+                if isinstance(v, int) or self.is_valid_uuid(v):
+                    continue
+
+                # Special circumstances to set endpoint to search within
                 if k == "termination_a":
                     endpoint = CONVERT_TO_ID[data.get("termination_a_type")]
                 elif k == "termination_b":
@@ -916,8 +921,6 @@ class NautobotModule:
 
                 if isinstance(v, list):
                     data[k] = id_list
-                elif isinstance(v, int) or self.is_valid_uuid(v):
-                    pass
                 elif query_id:
                     data[k] = query_id.id
                 else:

--- a/tests/integration/targets/latest/tasks/device.yml
+++ b/tests/integration/targets/latest/tasks/device.yml
@@ -195,12 +195,18 @@
       - test_six['diff']['after']['state'] == "absent"
       - test_six['msg'] == "device R1-changed-name deleted"
 
-- name: "7 - Add primary_ip4/6 to test100"
+- name: "GRAB IP Address UUIDs for following tests"
+  ansible.builtin.set_fact:
+    ip4: "{{ lookup('networktocode.nautobot.lookup', 'ip-addresses', api_endpoint=nautobot_url, token=nautobot_token, api_filter='address=172.16.180.1/24') }}"
+    ip6: "{{ lookup('networktocode.nautobot.lookup', 'ip-addresses', api_endpoint=nautobot_url, token=nautobot_token, api_filter='address=2001::1:1/64') }}"
+
+- name: "7 - Add primary_ip4/6 to test100 with UUID and regular definition"
   networktocode.nautobot.device:
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
     name: "test100"
-    primary_ip4: "172.16.180.1/24"
+    # This will test the UUID for ip4
+    primary_ip4: "{{ ip4['key'] }}"
     primary_ip6: "2001::1:1/64"
     status: "Active"
     state: present
@@ -220,9 +226,6 @@
       - test_seven['device']['primary_ip4'] == ip4['key']
       - test_seven['device']['primary_ip6'] == ip6['key']
       - test_seven['msg'] == "device test100 updated"
-  vars:
-    ip4: "{{ lookup('networktocode.nautobot.lookup', 'ip-addresses', api_endpoint=nautobot_url, token=nautobot_token, api_filter='address=172.16.180.1/24') }}"
-    ip6: "{{ lookup('networktocode.nautobot.lookup', 'ip-addresses', api_endpoint=nautobot_url, token=nautobot_token, api_filter='address=2001::1:1/64') }}"
 
 - name: "8 - Device with empty string name"
   networktocode.nautobot.device:


### PR DESCRIPTION
There is a bug if you provide a UUID to search for an IP address, it attempts to make a GET call and fails due to the API wanting an IP address. This should bypass that and for any other use cases where the users is providing the UUID.