### PR TITLE
Fix Follow Redirects Issue

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: networktocode
 name: nautobot
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.1.1
+version: 3.1.2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/inventory/gql_inventory.py
+++ b/plugins/inventory/gql_inventory.py
@@ -32,6 +32,12 @@ DOCUMENTATION = """
           description: Timeout for Nautobot requests in seconds
           type: int
           default: 60
+      follow_redirects:
+          description:
+              - Determine how redirects are followed.
+              - By default, I(follow_redirects) is set to uses urllib2 default behavior.
+          default: urllib2
+          choices: ['urllib2', 'all', 'yes', 'safe', 'none']
       validate_certs:
           description:
               - Allows connection when SSL certificates are not valid. Set to C(false) when certificates are not trusted.
@@ -198,7 +204,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         try:
             response = open_url(
-                self.api_endpoint + "/",
+                self.api_endpoint + "/api/graphql/",
                 method="post",
                 data=json.dumps(data),
                 headers=self.headers,
@@ -304,5 +310,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self.group_by = self.get_option("group_by")
         self.filters = self.get_option("filters")
         self.variables = self.get_option("additional_variables")
+        self.follow_redirects = self.get_option("follow_redirects")
 
         self.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot_ansible_modules"
-version = "3.1.1"
+version = "3.1.2"
 description = "Ansible collection to interact with Nautobot's API"
 authors = ["Network to Code <opensource@networktocode.com"]
 license = "Apache 2.0"


### PR DESCRIPTION
Fixes #103 

- Fixes follow redirects issue for GQL inventory
- Includes the API URL for the graphql endpoint

Fixed with including `follow_redirects` into the documentation, providing a default. Then adding as a self option. 

