### PR TITLE
Fix check mode in graphql action plugin.

### DIFF
--- a/plugins/action/query_graphql.py
+++ b/plugins/action/query_graphql.py
@@ -117,7 +117,7 @@ class ActionModule(ActionBase):
                 PYNAUTOBOT_IMPORT_ERROR,
             )
 
-        self._supports_check_mode = False
+        self._supports_check_mode = True
         self._supports_async = False
 
         result = super(ActionModule, self).run(tmp, task_vars)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot_ansible_modules"
-version = "3.3.0"
+version = "3.3.1"
 description = "Ansible collection to interact with Nautobot's API"
 authors = ["Network to Code <opensource@networktocode.com"]
 license = "Apache 2.0"


### PR DESCRIPTION
Hi @jvanderaa,

By looking at this [comment](https://github.com/nautobot/nautobot-ansible/blob/develop/plugins/modules/query_graphql.py#L159), I believe intention is that the module supports check mode and returns data when check mode is enabled.

At the same time in action plugin itself the `self._supports_check_mode` is set to `False` which effectively disables check mode and module returns info that check mode is not supported.

By setting `self._supports_check_mode` to `True` the module returns data even when check mode enabled.