### PR TITLE
Update primary ipv4 address

### DIFF
--- a/plugins/inventory/gql_inventory.py
+++ b/plugins/inventory/gql_inventory.py
@@ -177,7 +177,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def add_ipv4_address(self, device):
         """Add primary IPv4 address to host."""
         if device["primary_ip4"]:
-            self.add_variable(device["name"], device["primary_ip4"]["address"], "ansible_host")
+            self.add_variable(device["name"], device["primary_ip4"]["host"], "ansible_host")
         else:
             self.add_variable(device["name"], device["name"], "ansible_host")
 

--- a/plugins/templates/graphql_default_query.j2
+++ b/plugins/templates/graphql_default_query.j2
@@ -7,7 +7,7 @@ devices {% include "graphql_filters.j2" %} {
     name
   }
   primary_ip4 {
-    address
+    host
   }
   device_role {
     name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot_ansible_modules"
-version = "3.3.1"
+version = "3.3.2"
 description = "Ansible collection to interact with Nautobot's API"
 authors = ["Network to Code <opensource@networktocode.com"]
 license = "Apache 2.0"

--- a/tests/unit/inventory/test_data/graphql_groups/device_data.json
+++ b/tests/unit/inventory/test_data/graphql_groups/device_data.json
@@ -7,7 +7,7 @@
         "name": "Active"
     },
     "primary_ip4": {
-        "address": "10.10.10.10/32"
+        "host": "10.10.10.10"
     },
     "device_role": {
         "name": "edge",

--- a/tests/unit/inventory/test_graphql.py
+++ b/tests/unit/inventory/test_graphql.py
@@ -133,7 +133,7 @@ def test_add_ipv4(inventory_fixture, device_data):
     inventory_fixture.create_groups(device_data)
     inventory_fixture.add_ipv4_address(device_data)
     mydevice_host = inventory_fixture.inventory.get_host("mydevice")
-    assert mydevice_host.vars.get("ansible_host") == "10.10.10.10/32"
+    assert mydevice_host.vars.get("ansible_host") == "10.10.10.10"
 
 
 def test_ansible_platform(inventory_fixture, device_data):


### PR DESCRIPTION
Currently, the `ansible_host` variable gets populated with the CIDR from Nautobot. This change only populates `ansible_host` with the host IP address. 

Current implementation:
![ips](https://user-images.githubusercontent.com/38091261/158473263-1ab11ea6-2ae3-4f5e-a5ca-851a6e5f2c2f.png)

Proposed implementation:
![updated_ips](https://user-images.githubusercontent.com/38091261/158473448-b0099d8d-5cf8-4f11-a669-214ceccfe964.png)

 