### PR TITLE
Fix inventory.py to work with nautobot 1.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,19 +50,19 @@ jobs:
         # ansible-release: ["base", "core"]
         include:
           - python-version: "3.7"
-            nautobot-version: "1.0.3"
+            nautobot-version: "1.1.6"
             ansible-release: "base" # Ansible 2.10
           - python-version: "3.8"
-            nautobot-version: "1.1.1"
+            nautobot-version: "1.2"
             ansible-release: "2.11"
           - python-version: "3.8"
-            nautobot-version: "1.1.1"
+            nautobot-version: "1.2"
             ansible-release: "2.9"
           - python-version: "3.8"
-            nautobot-version: "1.1.3"
+            nautobot-version: "1.3"
             ansible-release: "2.10"
           - python-version: "3.8"
-            nautobot-version: "1.1.3"
+            nautobot-version: "1.3"
             ansible-release: "2.12"
     env:
       INVOKE_NAUTOBOT_ANSIBLE_PYTHON_VER: "${{ matrix.python-version }}"

--- a/plugins/inventory/inventory.py
+++ b/plugins/inventory/inventory.py
@@ -1071,8 +1071,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         openapi = self._fetch_information(self.api_endpoint + "/api/docs/?format=openapi")
 
         self.api_version = openapi["info"]["version"]
-        self.allowed_device_query_parameters = [p["name"] for p in openapi["paths"]["/dcim/devices/"]["get"]["parameters"]]
-        self.allowed_vm_query_parameters = [p["name"] for p in openapi["paths"]["/virtualization/virtual-machines/"]["get"]["parameters"]]
+        self.allowed_device_query_parameters = [p["name"] for p in openapi["paths"]["/api/dcim/devices/"]["get"]["parameters"]]
+        self.allowed_vm_query_parameters = [p["name"] for p in openapi["paths"]["/api/virtualization/virtual-machines/"]["get"]["parameters"]]
 
     def validate_query_parameter(self, parameter, allowed_query_parameters):
         if not (isinstance(parameter, dict) and len(parameter) == 1):

--- a/plugins/inventory/inventory.py
+++ b/plugins/inventory/inventory.py
@@ -1073,7 +1073,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self.api_version = openapi["info"]["version"]
 
         device_path = "/api/dcim/devices/" if "/api/dcim/devices/" in openapi["paths"] else "/dcim/devices/"
-        vm_path = "/api/virtualization/virtual-machines/" if "/api/virtualization/virtual-machines/" in openapi["paths"] else "/virtualization/virtual-machines"
+        vm_path = (
+            "/api/virtualization/virtual-machines/" if "/api/virtualization/virtual-machines/" in openapi["paths"] else "/virtualization/virtual-machines/"
+        )
 
         self.allowed_device_query_parameters = [p["name"] for p in openapi["paths"][device_path]["get"]["parameters"]]
         self.allowed_vm_query_parameters = [p["name"] for p in openapi["paths"][vm_path]["get"]["parameters"]]

--- a/plugins/inventory/inventory.py
+++ b/plugins/inventory/inventory.py
@@ -1071,8 +1071,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         openapi = self._fetch_information(self.api_endpoint + "/api/docs/?format=openapi")
 
         self.api_version = openapi["info"]["version"]
-        self.allowed_device_query_parameters = [p["name"] for p in openapi["paths"]["/api/dcim/devices/"]["get"]["parameters"]]
-        self.allowed_vm_query_parameters = [p["name"] for p in openapi["paths"]["/api/virtualization/virtual-machines/"]["get"]["parameters"]]
+        
+        device_path = "/api/dcim/devices/" if "/api/dcim/devices/" in openapi["paths"] else "/dcim/devices/"
+        vm_path = "/api/virtualization/virtual-machines/" if "/api/virtualization/virtual-machines/" in openapi["paths"] else "/virtualization/virtual-machines"
+
+        self.allowed_device_query_parameters = [p["name"] for p in openapi["paths"][device_path]["get"]["parameters"]]
+        self.allowed_vm_query_parameters = [p["name"] for p in openapi["paths"][vm_path]["get"]["parameters"]]
 
     def validate_query_parameter(self, parameter, allowed_query_parameters):
         if not (isinstance(parameter, dict) and len(parameter) == 1):

--- a/plugins/inventory/inventory.py
+++ b/plugins/inventory/inventory.py
@@ -1071,7 +1071,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         openapi = self._fetch_information(self.api_endpoint + "/api/docs/?format=openapi")
 
         self.api_version = openapi["info"]["version"]
-        
+
         device_path = "/api/dcim/devices/" if "/api/dcim/devices/" in openapi["paths"] else "/dcim/devices/"
         vm_path = "/api/virtualization/virtual-machines/" if "/api/virtualization/virtual-machines/" in openapi["paths"] else "/virtualization/virtual-machines"
 


### PR DESCRIPTION
Since upgrading to nautobot 1.3.1 the inventory plugin errors with:

```
  File "/home/appuser/.ansible/collections/ansible_collections/networktocode/nautobot/plugins/inventory/inventory.py", line 1349, in main
    self.fetch_api_docs()
  File "/home/appuser/.ansible/collections/ansible_collections/networktocode/nautobot/plugins/inventory/inventory.py", line 1074, in fetch_api_docs
    self.allowed_device_query_parameters = [p["name"] for p in openapi["paths"]["/dcim/devices/"]["get"]["parameters"]]
```

It seems `/api` was missing from the paths when getting device and vm query parameters, adding it resolves the issue.
