### PR TITLE
Fixes GraphQL inventory `group_by` when the value is empty

### DIFF
--- a/plugins/inventory/gql_inventory.py
+++ b/plugins/inventory/gql_inventory.py
@@ -299,6 +299,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 else:
                     self.display.display(f"No slug or name value for {group_name} in {group_by_path} on device {device_name}.")
 
+            if not group_name:
+                # If the value is empty, it can't be grouped
+                continue
+
             if isinstance(group_name, str):
                 # If using force_valid_group_names=always in ansible.cfg, hyphens in Nautobot slugs will be converted to underscores
                 group = self.inventory.add_group(group_name)

--- a/tests/unit/inventory/test_graphql.py
+++ b/tests/unit/inventory/test_graphql.py
@@ -128,6 +128,14 @@ def test_group_name_dict(mock_display, inventory_fixture, device_data):
     mock_display.assert_any_call("No slug or name value for {'napalm_driver': 'asa'} in platform on device mydevice.")
 
 
+def test_group_by_empty_string(inventory_fixture, device_data):
+    device_data["platform"]["napalm_driver"] = ""
+    inventory_fixture.group_by = ["platform.napalm_driver"]
+    inventory_fixture.create_groups(device_data)
+    inventory_groups = list(inventory_fixture.inventory.groups.keys())
+    assert ["all", "ungrouped"] == inventory_groups
+
+
 def test_add_ipv4(inventory_fixture, device_data):
     inventory_fixture.group_by = ["site"]
     inventory_fixture.create_groups(device_data)


### PR DESCRIPTION
Fixes: #151 