### PR TITLE
Fix api_filter to allow UUIDs

### DIFF
--- a/plugins/lookup/lookup.py
+++ b/plugins/lookup/lookup.py
@@ -330,7 +330,7 @@ class LookupModule(LookupBase):
                 if "id" in filter:
                     Display().vvvv("Filter is: %s and includes id, will use .get instead of .filter" % (filter))
                     try:
-                        id = int(filter["id"][0])
+                        id = filter["id"][0]
                         data = endpoint.get(id)
                         data = dict(data)
                         Display().vvvvv(pformat(data))


### PR DESCRIPTION
In the existing code, trying to filter by `id` leads to the `id` being turned into an `int`. However, UUIDs are actually non-integer strings, so, if anything, we should be checking that the value is a UUID.

However, I simply removed the checking entirely to preserve the behaviour of the [example lookup with id=1 from the forked Netbox code](https://github.com/nautobot/nautobot-ansible/blob/bccfd3c213cada58bdf6a90c1d40d3d60e2850cf/tests/integration/targets/v2.8/tasks/netbox_lookup.yml).

As a result of the change, the original behaviour should be preserved as well as supporting this type of use:
```
{{ query('networktocode.nautobot.lookup', 'devices', api_filter='id=an_actual_uuid', api_endpoint=nautobot_endpoint, token=nautobot_token) }}
```