### PR TITLE
Documentation adjustment to correct incorrect key name

### DIFF
--- a/docs/plugins/tenant_module.rst
+++ b/docs/plugins/tenant_module.rst
@@ -638,7 +638,7 @@ Examples
             url: http://nautobot.local
             token: thisIsMyToken
             name: Tenant ABC
-            group: Very Special Tenants
+            tenant_group: Very Special Tenants
             description: ABC Incorporated
             comments: '### This tenant is super cool'
             slug: tenant_abc

--- a/plugins/modules/tenant.py
+++ b/plugins/modules/tenant.py
@@ -130,7 +130,7 @@ EXAMPLES = r"""
         url: http://nautobot.local
         token: thisIsMyToken
         name: Tenant ABC
-        group: Very Special Tenants
+        tenant_group: Very Special Tenants
         description: ABC Incorporated
         comments: '### This tenant is super cool'
         slug: tenant_abc


### PR DESCRIPTION
The module `networktocode.nautobot.tenant` supports the usage of `tenant_group`, but the documentation refers to an incorrect name of `group`, causing the module to fail upon execution.

```
"msg": "Unsupported parameters for (tenant) module: group. Supported parameters include: state, comments, url, validate_certs, tenant_group, description, custom_fields, slug, name, token, api_version, query_params, tags."}
````