### PR TITLE
Moves duplicate documentation to fragments

### DIFF
--- a/plugins/doc_fragments/fragments.py
+++ b/plugins/doc_fragments/fragments.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2023, Network to Code (@networktocode) <info@networktocode.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+BASE = r"""
+requirements:
+  - pynautobot
+options:
+  url:
+    description:
+      - "The URL of the Nautobot instance resolvable by the Ansible host (for example: http://nautobot.example.com:8000)"
+    required: true
+    type: str
+  token:
+    description:
+      - "The token created within Nautobot to authorize API access"
+    required: true
+    type: str
+  state:
+    description:
+      - "Use C(present) or C(absent) for adding or removing."
+    choices: [ absent, present ]
+    default: present
+    type: str
+  query_params:
+    version_added: "3.0.0"
+    description:
+      - "This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined"
+      - "in plugins/module_utils/utils.py and provides control to users on what may make"
+      - "an object unique in their environment."
+    required: false
+    type: list
+    elements: str
+  validate_certs:
+    description:
+      - "If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates."
+    required: false
+    default: true
+    type: raw
+  api_version:
+    version_added: "4.1.0"
+    description:
+      - "API Version Nautobot REST API"
+    required: false
+    type: str
+"""
+
+TAGS = r"""
+options:
+  tags:
+    description:
+      - "Any tags that this item may need to be associated with"
+    required: false
+    type: list
+    elements: raw
+    version_added: "3.0.0"
+"""
+
+CUSTOM_FIELDS = r"""
+options:
+  custom_fields:
+    description:
+      - "Must exist in Nautobot and in key/value format"
+    required: false
+    type: dict
+    version_added: "3.0.0"
+"""
+
+
+class ModuleDocFragment(object):
+    BASE = BASE
+    TAGS = TAGS
+    CUSTOM_FIELDS = CUSTOM_FIELDS

--- a/plugins/doc_fragments/fragments.py
+++ b/plugins/doc_fragments/fragments.py
@@ -6,7 +6,9 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-BASE = r"""
+
+class ModuleDocFragment(object):
+    BASE = r"""
 requirements:
   - pynautobot
 options:
@@ -49,7 +51,7 @@ options:
     type: str
 """
 
-TAGS = r"""
+    TAGS = r"""
 options:
   tags:
     description:
@@ -60,7 +62,7 @@ options:
     version_added: "3.0.0"
 """
 
-CUSTOM_FIELDS = r"""
+    CUSTOM_FIELDS = r"""
 options:
   custom_fields:
     description:
@@ -69,9 +71,3 @@ options:
     type: dict
     version_added: "3.0.0"
 """
-
-
-class ModuleDocFragment(object):
-    BASE = BASE
-    TAGS = TAGS
-    CUSTOM_FIELDS = CUSTOM_FIELDS

--- a/plugins/modules/aggregate.py
+++ b/plugins/modules/aggregate.py
@@ -18,26 +18,12 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - "URL of the Nautobot instance resolvable by Ansible control host"
-    required: true
-    type: str
-  token:
-    description:
-      - "The token created within Nautobot to authorize API access"
-    required: true
-    type: str
   prefix:
     description:
       - "The aggregate prefix"
@@ -62,39 +48,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  tags:
-    description:
-      - "Any tags that the aggregate may need to be associated with"
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  custom_fields:
-    description:
-      - "must exist in Nautobot"
-    required: false
-    type: dict
-    version_added: "3.0.0"
-  state:
-    description:
-      - "The state of the aggregate"
-    choices: [ present, absent ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - "If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates."
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/cable.py
+++ b/plugins/modules/cable.py
@@ -19,26 +19,10 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Tobias Groß (@toerb)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   termination_a_type:
     description:
       - The type of the termination a
@@ -146,26 +130,6 @@ options:
       - in
     required: false
     type: str
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    version_added: "3.0.0"
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/circuit.py
+++ b/plugins/modules/circuit.py
@@ -19,26 +19,12 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   cid:
     description:
       - The circuit id of the circuit
@@ -94,39 +80,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the device may need to be associated with
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  custom_fields:
-    description:
-      - must exist in Nautobot
-    required: false
-    type: dict
-    version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/circuit_termination.py
+++ b/plugins/modules/circuit_termination.py
@@ -18,26 +18,10 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   circuit:
     description:
       - The circuit to assign to circuit termination
@@ -95,26 +79,6 @@ options:
       - Connection to a provider_network type
     type: raw
     required: false
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    version_added: "3.0.0"
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/circuit_type.py
+++ b/plugins/modules/circuit_type.py
@@ -18,26 +18,10 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   name:
     description:
       - The name of the circuit type
@@ -51,26 +35,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/cluster.py
+++ b/plugins/modules/cluster.py
@@ -18,26 +18,12 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Gaelle MANGIN (@gmangin)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   name:
     description:
       - The name of the cluster
@@ -74,39 +60,6 @@ options:
     required: false
     type: raw
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the cluster may need to be associated with
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  custom_fields:
-    description:
-      - must exist in Nautobot
-    required: false
-    type: dict
-    version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/cluster_group.py
+++ b/plugins/modules/cluster_group.py
@@ -18,26 +18,10 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   name:
     description:
       - The name of the cluster group
@@ -51,26 +35,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default:  true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/cluster_type.py
+++ b/plugins/modules/cluster_type.py
@@ -18,26 +18,10 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   name:
     description:
       - The name of the cluster type
@@ -51,26 +35,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/console_port.py
+++ b/plugins/modules/console_port.py
@@ -19,26 +19,11 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Tobias Groß (@toerb)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   device:
     description:
       - The device the console port is attached to
@@ -77,33 +62,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the console port may need to be associated with
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/console_port_template.py
+++ b/plugins/modules/console_port_template.py
@@ -19,26 +19,10 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Tobias Groß (@toerb)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   device_type:
     description:
       - The device type the console port template is attached to
@@ -71,26 +55,6 @@ options:
       - other
     required: false
     type: str
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/console_server_port.py
+++ b/plugins/modules/console_server_port.py
@@ -19,26 +19,11 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Tobias Groß (@toerb)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   device:
     description:
       - The device the console server port is attached to
@@ -77,33 +62,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the console server port may need to be associated with
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/console_server_port_template.py
+++ b/plugins/modules/console_server_port_template.py
@@ -19,26 +19,10 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Tobias Groß (@toerb)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   device_type:
     description:
       - The device type the console server port template is attached to
@@ -71,26 +55,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/device.py
+++ b/plugins/modules/device.py
@@ -20,26 +20,12 @@ notes:
 author:
   - Mikhail Yohman (@FragmentedPacket)
   - David Gomez (@amb1s1)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   name:
     description:
       - The name of the device
@@ -160,45 +146,12 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the device may need to be associated with
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  custom_fields:
-    description:
-      - must exist in Nautobot
-    required: false
-    type: dict
-    version_added: "3.0.0"
   local_context_data:
     description:
       - Arbitrary JSON data to define the devices configuration variables.
     required: false
     type: dict
     version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/device_bay.py
+++ b/plugins/modules/device_bay.py
@@ -18,26 +18,11 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   device:
     description:
       - The device the device bay will be associated to. The device type must be "parent".
@@ -62,33 +47,6 @@ options:
     required: false
     type: raw
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the device bay may need to be associated with
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/device_bay_template.py
+++ b/plugins/modules/device_bay_template.py
@@ -19,26 +19,10 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Tobias Groß (@toerb)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   device_type:
     description:
       - The device type the device bay template will be associated to. The device type must be "parent".
@@ -51,26 +35,6 @@ options:
     required: true
     type: str
     version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/device_interface.py
+++ b/plugins/modules/device_interface.py
@@ -18,26 +18,12 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   device:
     description:
       - Name of the device the interface will be associated with (case-sensitive)
@@ -119,19 +105,6 @@ options:
     required: false
     type: raw
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the interface may need to be associated with
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  custom_fields:
-    description:
-      - Allows modification of any custom tags on the interface. The custom field must already exist in the model
-    required: false
-    type: dict
-    version_added: "3.0.0"
   update_vc_child:
     type: bool
     default: False
@@ -140,28 +113,6 @@ options:
         Use when master device is specified for C(device) and the specified interface exists on a child device
         and needs updated
     version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - |
-        If C(no), SSL certificates will not be validated.
-        This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/device_interface_template.py
+++ b/plugins/modules/device_interface_template.py
@@ -19,26 +19,10 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Tobias Groß (@toerb)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   device_type:
     description:
       - Name of the device the interface template will be associated with (case-sensitive)
@@ -66,28 +50,6 @@ options:
     required: false
     type: bool
     version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - |
-        If C(no), SSL certificates will not be validated.
-        This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/device_role.py
+++ b/plugins/modules/device_role.py
@@ -18,26 +18,10 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   name:
     description:
       - The name of the device role
@@ -68,26 +52,6 @@ options:
       - Whether the role is a VM role
     type: bool
     version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/device_type.py
+++ b/plugins/modules/device_type.py
@@ -18,26 +18,12 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   manufacturer:
     description:
       - The manufacturer of the device type
@@ -93,39 +79,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the device type may need to be associated with
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  custom_fields:
-    description:
-      - must exist in Nautobot
-    required: false
-    type: dict
-    version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/front_port.py
+++ b/plugins/modules/front_port.py
@@ -19,26 +19,11 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Tobias Groß (@toerb)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   device:
     description:
       - The device the front port is attached to
@@ -90,33 +75,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the front port may need to be associated with
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""
@@ -190,7 +148,22 @@ def main():
             name=dict(required=True, type="str"),
             type=dict(
                 required=True,
-                choices=["8p8c", "110-punch", "bnc", "mrj21", "fc", "lc", "lc-apc", "lsh", "lsh-apc", "mpo", "mtrj", "sc", "sc-apc", "st"],
+                choices=[
+                    "8p8c",
+                    "110-punch",
+                    "bnc",
+                    "mrj21",
+                    "fc",
+                    "lc",
+                    "lc-apc",
+                    "lsh",
+                    "lsh-apc",
+                    "mpo",
+                    "mtrj",
+                    "sc",
+                    "sc-apc",
+                    "st",
+                ],
                 type="str",
             ),
             rear_port=dict(required=True, type="raw"),

--- a/plugins/modules/front_port_template.py
+++ b/plugins/modules/front_port_template.py
@@ -19,26 +19,10 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Tobias Groß (@toerb)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   device_type:
     description:
       - The device type the front port template is attached to
@@ -94,26 +78,6 @@ options:
     required: false
     type: int
     version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/inventory_item.py
+++ b/plugins/modules/inventory_item.py
@@ -18,26 +18,11 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   device:
     description:
       - Name of the device the inventory item belongs to
@@ -87,35 +72,6 @@ options:
     default: false
     type: bool
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the device may need to be associated with
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - |
-        If C(no), SSL certificates will not be validated.
-        This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/ip_address.py
+++ b/plugins/modules/ip_address.py
@@ -19,26 +19,12 @@ notes:
 author:
   - Mikhail Yohman (@FragmentedPacket)
   - Anthony Ruhier (@Anthony25)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   address:
     description:
       - Required if state is C(present)
@@ -134,19 +120,6 @@ options:
         type: str
         required: False
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the IP address may need to be associated with
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  custom_fields:
-    description:
-      - must exist in Nautobot
-    required: false
-    type: dict
-    version_added: "3.0.0"
   state:
     description:
       - |
@@ -157,20 +130,6 @@ options:
     choices: [ absent, new, present ]
     default: present
     type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/ipam_role.py
+++ b/plugins/modules/ipam_role.py
@@ -18,26 +18,10 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   name:
     description:
       - Name of the ipam role to be created
@@ -57,28 +41,6 @@ options:
     required: false
     type: int
     version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - |
-        If C(no), SSL certificates will not be validated.
-        This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/manufacturer.py
+++ b/plugins/modules/manufacturer.py
@@ -18,26 +18,10 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   name:
     description:
       - The name of the manufacturer
@@ -57,26 +41,6 @@ options:
     required: false
     type: str
     version_added: "4.2.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/platform.py
+++ b/plugins/modules/platform.py
@@ -18,26 +18,10 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   name:
     description:
       - The name of the platform
@@ -75,26 +59,6 @@ options:
     required: false
     type: dict
     version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/power_feed.py
+++ b/plugins/modules/power_feed.py
@@ -19,26 +19,12 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Tobias Groß (@toerb)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   power_panel:
     description:
       - The power panel the power feed is terminated on
@@ -115,39 +101,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the power feed may need to be associated with
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  custom_fields:
-    description:
-      - must exist in Nautobot
-    required: false
-    type: dict
-    version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/power_outlet.py
+++ b/plugins/modules/power_outlet.py
@@ -19,26 +19,11 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Tobias Groß (@toerb)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   device:
     description:
       - The device the power outlet is attached to
@@ -134,33 +119,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the power outlet may need to be associated with
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/power_outlet_template.py
+++ b/plugins/modules/power_outlet_template.py
@@ -19,26 +19,10 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Tobias Groß (@toerb)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   device_type:
     description:
       - The device type the power outlet is attached to
@@ -128,26 +112,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/power_panel.py
+++ b/plugins/modules/power_panel.py
@@ -19,26 +19,10 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Tobias Groß (@toerb)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   site:
     description:
       - The site the power panel is located in
@@ -57,26 +41,6 @@ options:
     required: true
     type: str
     version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/power_port.py
+++ b/plugins/modules/power_port.py
@@ -19,26 +19,11 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Tobias Groß (@toerb)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   device:
     description:
       - The device the power port is attached to
@@ -130,33 +115,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the power port may need to be associated with
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/power_port_template.py
+++ b/plugins/modules/power_port_template.py
@@ -19,26 +19,10 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Tobias Groß (@toerb)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   device_type:
     description:
       - The device type the power port is attached to
@@ -124,26 +108,6 @@ options:
     required: false
     type: int
     version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/prefix.py
+++ b/plugins/modules/prefix.py
@@ -19,26 +19,12 @@ notes:
 author:
   - Mikhail Yohman (@FragmentedPacket)
   - Anthony Ruhier (@Anthony25)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   family:
     description:
       - Specifies which address family the prefix prefix belongs to
@@ -114,25 +100,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the prefix may need to be associated with
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  custom_fields:
-    description:
-      - Must exist in Nautobot and in key/value format
-    required: false
-    type: dict
-    version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
   first_available:
     description:
       - If C(yes) and state C(present), if an parent is given, it will get the
@@ -142,20 +109,6 @@ options:
     default: false
     type: bool
     version_added: "3.0.0"
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/provider.py
+++ b/plugins/modules/provider.py
@@ -18,26 +18,12 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   name:
     description:
       - The name of the provider
@@ -80,39 +66,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the device may need to be associated with
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  custom_fields:
-    description:
-      - must exist in Nautobot
-    required: false
-    type: dict
-    version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/rack.py
+++ b/plugins/modules/rack.py
@@ -19,26 +19,12 @@ notes:
   - The module supports C(check_mode).
 author:
   - NMikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host.
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access.
-    required: true
-    type: str
   name:
     description:
       - The name of the rack.
@@ -156,39 +142,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the rack may need to be associated with.
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  custom_fields:
-    description:
-      - Must exist in Nautobot.
-    required: false
-    type: dict
-    version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""
@@ -254,7 +207,13 @@ def main():
             type=dict(
                 required=False,
                 type="str",
-                choices=["2-post frame", "4-post frame", "4-post cabinet", "Wall-mounted frame", "Wall-mounted cabinet"],
+                choices=[
+                    "2-post frame",
+                    "4-post frame",
+                    "4-post cabinet",
+                    "Wall-mounted frame",
+                    "Wall-mounted cabinet",
+                ],
             ),
             width=dict(required=False, type="int", choices=[10, 19, 21, 23]),
             u_height=dict(required=False, type="int"),

--- a/plugins/modules/rack_group.py
+++ b/plugins/modules/rack_group.py
@@ -18,26 +18,10 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   description:
     description:
       - The description of the rack group
@@ -75,26 +59,6 @@ options:
     required: false
     type: raw
     version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/rack_role.py
+++ b/plugins/modules/rack_role.py
@@ -18,26 +18,10 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   name:
     description:
       - The name of the rack role
@@ -57,26 +41,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/rear_port.py
+++ b/plugins/modules/rear_port.py
@@ -19,27 +19,11 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Tobias Groß (@toerb)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
-    version_added: "3.0.0"
   device:
     description:
       - The device the rear port is attached to
@@ -85,33 +69,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the rear port may need to be associated with
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""
@@ -182,7 +139,22 @@ def main():
             name=dict(required=True, type="str"),
             type=dict(
                 required=True,
-                choices=["8p8c", "110-punch", "bnc", "mrj21", "fc", "lc", "lc-apc", "lsh", "lsh-apc", "mpo", "mtrj", "sc", "sc-apc", "st"],
+                choices=[
+                    "8p8c",
+                    "110-punch",
+                    "bnc",
+                    "mrj21",
+                    "fc",
+                    "lc",
+                    "lc-apc",
+                    "lsh",
+                    "lsh-apc",
+                    "mpo",
+                    "mtrj",
+                    "sc",
+                    "sc-apc",
+                    "st",
+                ],
                 type="str",
             ),
             positions=dict(required=False, type="int"),

--- a/plugins/modules/rear_port_template.py
+++ b/plugins/modules/rear_port_template.py
@@ -19,26 +19,10 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Tobias Groß (@toerb)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   device_type:
     description:
       - The device type the rear port template is attached to
@@ -88,26 +72,6 @@ options:
     required: false
     type: int
     version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/region.py
+++ b/plugins/modules/region.py
@@ -18,26 +18,10 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   name:
     description:
       - Name of the region to be created
@@ -57,28 +41,6 @@ options:
     required: false
     type: raw
     version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - |
-        If C(no), SSL certificates will not be validated.
-        This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/relationship_association.py
+++ b/plugins/modules/relationship_association.py
@@ -16,26 +16,10 @@ description:
 author:
   - Network to Code (@networktocode)
   - Joe Wesch (@joewesch)
-requirements:
-  - pynautobot
 version_added: "4.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   relationship:
     description:
       - The Relationship UUID to add the association to
@@ -61,27 +45,6 @@ options:
       - The UUID of the destination of the relationship
     required: true
     type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  validate_certs:
-    description:
-      - |
-        If C(no), SSL certificates will not be validated.
-        This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/rir.py
+++ b/plugins/modules/rir.py
@@ -18,26 +18,10 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   name:
     description:
       - The name of the RIR
@@ -57,26 +41,6 @@ options:
     required: false
     type: bool
     version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/route_target.py
+++ b/plugins/modules/route_target.py
@@ -18,26 +18,12 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   name:
     description:
       - Route target name
@@ -55,41 +41,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the device may need to be associated with
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  custom_fields:
-    description:
-      - must exist in Nautobot
-    required: false
-    type: dict
-    version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - |
-        If C(no), SSL certificates will not be validated.
-        This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/service.py
+++ b/plugins/modules/service.py
@@ -18,26 +18,12 @@ notes:
   - The module supports C(check_mode).
 author:
   - Kulakov Ilya (@TawR1024)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host.
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access.
-    required: true
-    type: str
   device:
     description:
       - Specifies on which device the service is running.
@@ -80,39 +66,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  tags:
-    description:
-      - What tags to add/update.
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  custom_fields:
-    description:
-      - Must exist in Nautobot and in key/value format.
-    required: false
-    type: dict
-    version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/site.py
+++ b/plugins/modules/site.py
@@ -18,26 +18,12 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   name:
     description:
       - Name of the site to be created
@@ -140,41 +126,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the prefix may need to be associated with
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  custom_fields:
-    description:
-      - must exist in Nautobot
-    required: false
-    type: dict
-    version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - |
-        If C(no), SSL certificates will not be validated.
-        This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/status.py
+++ b/plugins/modules/status.py
@@ -19,26 +19,10 @@ author:
   - Network to Code (@networktocode)
   - Mikhail Yohman (@fragmentedpacket)
   - Josh VanDeraa (@jvanaderaa)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   name:
     description:
       - Status name
@@ -72,28 +56,6 @@ options:
     type: list
     elements: str
     version_added: "3.0.0"
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  validate_certs:
-    description:
-      - |
-        If C(no), SSL certificates will not be validated.
-        This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/tag.py
+++ b/plugins/modules/tag.py
@@ -18,26 +18,10 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Pavel Korovin (@pkorovin)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   name:
     description:
       - Tag name
@@ -70,28 +54,6 @@ options:
     required: false
     type: list
     elements: str
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - |
-        If C(no), SSL certificates will not be validated.
-        This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/tenant.py
+++ b/plugins/modules/tenant.py
@@ -18,26 +18,12 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Amy Liebowitz (@amylieb)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   name:
     description:
       - Name of the tenant to be created
@@ -68,41 +54,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the tenant may need to be associated with
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  custom_fields:
-    description:
-      - must exist in Nautobot
-    required: false
-    type: dict
-    version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - |
-        If C(no), SSL certificates will not be validated.
-        This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/tenant_group.py
+++ b/plugins/modules/tenant_group.py
@@ -18,26 +18,10 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   name:
     description:
       - Name of the tenant group to be created
@@ -56,34 +40,12 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
   parent_tenant_group:
     description:
       - Name of the parent tenant group
     required: false
     type: raw
     version_added: "3.1.0"
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - |
-        If C(no), SSL certificates will not be validated.
-        This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/virtual_chassis.py
+++ b/plugins/modules/virtual_chassis.py
@@ -19,26 +19,11 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Tobias Groß (@toerb)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   name:
     description:
       - Name
@@ -57,33 +42,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the virtual chassis may need to be associated with
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/virtual_machine.py
+++ b/plugins/modules/virtual_machine.py
@@ -18,26 +18,12 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Gaelle MANGIN (@gmangin)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   name:
     description:
       - The name of the virtual machine
@@ -111,18 +97,6 @@ options:
     required: false
     type: raw
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the virtual machine may need to be associated with
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  custom_fields:
-    description:
-      - Must exist in Nautobot
-    required: false
-    type: dict
   local_context_data:
     description:
       - configuration context of the virtual machine
@@ -135,26 +109,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/vlan.py
+++ b/plugins/modules/vlan.py
@@ -18,26 +18,12 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   site:
     description:
       - The site the VLAN will be associated to
@@ -87,39 +73,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the vlan may need to be associated with
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  custom_fields:
-    description:
-      - must exist in Nautobot
-    required: false
-    type: dict
-    version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/vlan_group.py
+++ b/plugins/modules/vlan_group.py
@@ -18,26 +18,10 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   name:
     description:
       - The name of the vlan group
@@ -63,26 +47,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/vm_interface.py
+++ b/plugins/modules/vm_interface.py
@@ -18,26 +18,11 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Benjamin Vergnaud (@bvergnaud)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   virtual_machine:
     description:
       - Name of the virtual machine the interface will be associated with (case-sensitive)
@@ -92,35 +77,6 @@ options:
     required: false
     type: raw
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the prefix may need to be associated with
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - |
-        If C(no), SSL certificates will not be validated.
-        This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/vrf.py
+++ b/plugins/modules/vrf.py
@@ -18,26 +18,12 @@ notes:
   - This should be ran with connection C(local) and hosts C(localhost)
 author:
   - Mikhail Yohman (@FragmentedPacket)
-requirements:
-  - pynautobot
 version_added: "1.0.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
-  api_version:
-    description:
-      - API Version Nautobot REST API
-    required: false
-    type: str
-    version_added: "4.1.0"
-  url:
-    description:
-      - URL of the Nautobot instance resolvable by Ansible control host
-    required: true
-    type: str
-  token:
-    description:
-      - The token created within Nautobot to authorize API access
-    required: true
-    type: str
   name:
     description:
       - The name of the vrf
@@ -82,39 +68,6 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
-  tags:
-    description:
-      - Any tags that the vrf may need to be associated with
-    required: false
-    type: list
-    elements: raw
-    version_added: "3.0.0"
-  custom_fields:
-    description:
-      - must exist in Nautobot
-    required: false
-    type: dict
-    version_added: "3.0.0"
-  state:
-    description:
-      - Use C(present) or C(absent) for adding or removing.
-    choices: [ absent, present ]
-    default: present
-    type: str
-  query_params:
-    description:
-      - This can be used to override the specified values in ALLOWED_QUERY_PARAMS that is defined
-      - in plugins/module_utils/utils.py and provides control to users on what may make
-      - an object unique in their environment.
-    required: false
-    type: list
-    elements: str
-    version_added: "3.0.0"
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-    default: true
-    type: raw
 """
 
 EXAMPLES = r"""


### PR DESCRIPTION
This PR simply consolidates and standardizes most common documentation items into [fragments](https://docs.ansible.com/ansible/latest/plugins/docs_fragment.html).

Notes:
- The 2 modules not using fragments are `nautobot_server` and `query_graphql`.
- The `ip_address` module defines and uses a different `state` option, but module level documentation overrides items inherited from a fragment.