### PR TITLE
Add plugins module.

### DIFF
--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -1,0 +1,7 @@
+ARG NAUTOBOT_VER
+ARG PYTHON_VER
+
+FROM ghcr.io/nautobot/nautobot:${NAUTOBOT_VER}-py${PYTHON_VER} as nautobot
+
+RUN pip install nautobot-bgp-models
+COPY ./development/nautobot_config.py /opt/nautobot/nautobot_config.py

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -1,24 +1,36 @@
-version: "3"
+---
+x-nautobot-build: &nautobot-build
+  build:
+    args:
+      NAUTOBOT_VER: "${NAUTOBOT_VER}"
+      PYTHON_VER: "${PYTHON_VER}"
+    context: "../"
+    target: "nautobot"
+    dockerfile: "development/Dockerfile"
+x-nautobot-base: &nautobot-base
+  image: "nautobot/nautobot:local"
+  env_file:
+    - "dev.env"
+  tty: true
+
+version: "3.8"
 services:
   nautobot:
-    image: "ghcr.io/nautobot/nautobot:${NAUTOBOT_VER}-py${PYTHON_VER}"
-    command: "nautobot-server runserver 0.0.0.0:8000"
+    command: "nautobot-server runserver 0.0.0.0:8000 --insecure"
     ports:
       - "8000:8000"
     depends_on:
       - "postgres"
       - "redis"
-    env_file:
-      - "./dev.env"
-    tty: true
+    <<: *nautobot-build
+    <<: *nautobot-base
   worker:
-    image: "ghcr.io/nautobot/nautobot:${NAUTOBOT_VER}-py${PYTHON_VER}"
     entrypoint: "nautobot-server rqworker"
     depends_on:
       - "nautobot"
     env_file:
       - "./dev.env"
-    tty: true
+    <<: *nautobot-base
   postgres:
     image: "postgres:13"
     env_file:

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -1,12 +1,4 @@
 ---
-x-nautobot-build: &nautobot-build
-  build:
-    args:
-      NAUTOBOT_VER: "${NAUTOBOT_VER}"
-      PYTHON_VER: "${PYTHON_VER}"
-    context: "../"
-    target: "nautobot"
-    dockerfile: "development/Dockerfile"
 x-nautobot-base: &nautobot-base
   image: "nautobot/nautobot:local"
   env_file:
@@ -16,13 +8,19 @@ x-nautobot-base: &nautobot-base
 version: "3.8"
 services:
   nautobot:
+    build:
+      args:
+        NAUTOBOT_VER: "${NAUTOBOT_VER}"
+        PYTHON_VER: "${PYTHON_VER}"
+      context: "../"
+      target: "nautobot"
+      dockerfile: "development/Dockerfile"
     command: "nautobot-server runserver 0.0.0.0:8000 --insecure"
     ports:
       - "8000:8000"
     depends_on:
       - "postgres"
       - "redis"
-    <<: *nautobot-build
     <<: *nautobot-base
   worker:
     entrypoint: "nautobot-server rqworker"

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -28,8 +28,6 @@ services:
     entrypoint: "nautobot-server rqworker"
     depends_on:
       - "nautobot"
-    env_file:
-      - "./dev.env"
     <<: *nautobot-base
   postgres:
     image: "postgres:13"

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -30,9 +30,7 @@ DATABASES = {
         "USER": os.getenv("NAUTOBOT_DB_USER", ""),  # Database username
         "PASSWORD": os.getenv("NAUTOBOT_DB_PASSWORD", ""),  # Database password
         "HOST": os.getenv("NAUTOBOT_DB_HOST", "localhost"),  # Database server
-        "PORT": os.getenv(
-            "NAUTOBOT_DB_PORT", default_db_settings[nautobot_db_engine]["NAUTOBOT_DB_PORT"]
-        ),  # Database port, default to postgres
+        "PORT": os.getenv("NAUTOBOT_DB_PORT", default_db_settings[nautobot_db_engine]["NAUTOBOT_DB_PORT"]),  # Database port, default to postgres
         "CONN_MAX_AGE": int(os.getenv("NAUTOBOT_DB_TIMEOUT", 300)),  # Database timeout
         "ENGINE": nautobot_db_engine,
     }

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -1,0 +1,77 @@
+"""Nautobot development configuration file."""
+# pylint: disable=invalid-envvar-default
+import os
+import sys
+
+from nautobot.core.settings import *  # noqa: F403  # pylint: disable=wildcard-import,unused-wildcard-import
+from nautobot.core.settings_funcs import parse_redis_connection, is_truthy
+
+
+#
+# Misc. settings
+#
+
+ALLOWED_HOSTS = os.getenv("NAUTOBOT_ALLOWED_HOSTS", "").split(" ")
+SECRET_KEY = os.getenv("NAUTOBOT_SECRET_KEY", "")
+
+
+nautobot_db_engine = os.getenv("NAUTOBOT_DB_ENGINE", "django.db.backends.postgresql")
+default_db_settings = {
+    "django.db.backends.postgresql": {
+        "NAUTOBOT_DB_PORT": "5432",
+    },
+    "django.db.backends.mysql": {
+        "NAUTOBOT_DB_PORT": "3306",
+    },
+}
+DATABASES = {
+    "default": {
+        "NAME": os.getenv("NAUTOBOT_DB_NAME", "nautobot"),  # Database name
+        "USER": os.getenv("NAUTOBOT_DB_USER", ""),  # Database username
+        "PASSWORD": os.getenv("NAUTOBOT_DB_PASSWORD", ""),  # Database password
+        "HOST": os.getenv("NAUTOBOT_DB_HOST", "localhost"),  # Database server
+        "PORT": os.getenv(
+            "NAUTOBOT_DB_PORT", default_db_settings[nautobot_db_engine]["NAUTOBOT_DB_PORT"]
+        ),  # Database port, default to postgres
+        "CONN_MAX_AGE": int(os.getenv("NAUTOBOT_DB_TIMEOUT", 300)),  # Database timeout
+        "ENGINE": nautobot_db_engine,
+    }
+}
+
+# Ensure proper Unicode handling for MySQL
+if DATABASES["default"]["ENGINE"] == "django.db.backends.mysql":
+    DATABASES["default"]["OPTIONS"] = {"charset": "utf8mb4"}
+
+#
+# Redis
+#
+
+# The django-redis cache is used to establish concurrent locks using Redis. The
+# django-rq settings will use the same instance/database by default.
+#
+# This "default" server is now used by RQ_QUEUES.
+# >> See: nautobot.core.settings.RQ_QUEUES
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": parse_redis_connection(redis_database=0),
+        "TIMEOUT": 300,
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        },
+    }
+}
+
+# RQ_QUEUES is not set here because it just uses the default that gets imported
+# up top via `from nautobot.core.settings import *`.
+
+# Redis Cacheops
+CACHEOPS_REDIS = parse_redis_connection(redis_database=1)
+
+#
+# Celery settings are not defined here because they can be overloaded with
+# environment variables. By default they use `CACHES["default"]["LOCATION"]`.
+#
+
+# Enable installed plugins. Add the name of each plugin to the list.
+PLUGINS = ["nautobot_bgp_models"]

--- a/docs/plugins/plugin_module.rst
+++ b/docs/plugins/plugin_module.rst
@@ -1,0 +1,709 @@
+
+.. Document meta
+
+:orphan:
+
+.. |antsibull-internal-nbsp| unicode:: 0xA0
+    :trim:
+
+.. role:: ansible-attribute-support-label
+.. role:: ansible-attribute-support-property
+.. role:: ansible-attribute-support-full
+.. role:: ansible-attribute-support-partial
+.. role:: ansible-attribute-support-none
+.. role:: ansible-attribute-support-na
+.. role:: ansible-option-type
+.. role:: ansible-option-elements
+.. role:: ansible-option-required
+.. role:: ansible-option-versionadded
+.. role:: ansible-option-aliases
+.. role:: ansible-option-choices
+.. role:: ansible-option-choices-default-mark
+.. role:: ansible-option-default-bold
+.. role:: ansible-option-configuration
+.. role:: ansible-option-returned-bold
+.. role:: ansible-option-sample-bold
+
+.. Anchors
+
+.. _ansible_collections.networktocode.nautobot.plugin_module:
+
+.. Anchors: short name for ansible.builtin
+
+.. Anchors: aliases
+
+
+
+.. Title
+
+networktocode.nautobot.plugin module -- CRUD operation on plugin objects
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. Collection note
+
+.. note::
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/networktocode/nautobot>`_ (version 4.3.1).
+
+    To install it, use: :code:`ansible-galaxy collection install networktocode.nautobot`.
+    You need further requirements to be able to use this module,
+    see :ref:`Requirements <ansible_collections.networktocode.nautobot.plugin_module_requirements>` for details.
+
+    To use it in a playbook, specify: :code:`networktocode.nautobot.plugin`.
+
+.. version_added
+
+.. rst-class:: ansible-version-added
+
+New in networktocode.nautobot 4.4.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+.. Deprecated
+
+
+Synopsis
+--------
+
+.. Description
+
+- Creates, removes or updates various plugin objects in Nautobot
+
+
+.. Aliases
+
+
+.. Requirements
+
+.. _ansible_collections.networktocode.nautobot.plugin_module_requirements:
+
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- pynautobot
+
+
+
+
+
+
+.. Options
+
+Parameters
+----------
+
+.. rst-class:: ansible-option-table
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Parameter
+    - Comments
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-api_version"></div>
+
+      .. _ansible_collections.networktocode.nautobot.plugin_module__parameter-api_version:
+
+      .. rst-class:: ansible-option-title
+
+      **api_version**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-api_version" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+      :ansible-option-versionadded:`added in networktocode.nautobot 4.1.0`
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      API Version Nautobot REST API
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-attrs"></div>
+
+      .. _ansible_collections.networktocode.nautobot.plugin_module__parameter-attrs:
+
+      .. rst-class:: ansible-option-title
+
+      **attrs**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-attrs" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`dictionary`
+
+      :ansible-option-versionadded:`added in networktocode.nautobot 4.4.0`
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Object attributes other than identifier to create or update an object, like description, etc.
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-endpoint"></div>
+
+      .. _ansible_collections.networktocode.nautobot.plugin_module__parameter-endpoint:
+
+      .. rst-class:: ansible-option-title
+
+      **endpoint**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-endpoint" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string` / :ansible-option-required:`required`
+
+      :ansible-option-versionadded:`added in networktocode.nautobot 4.4.0`
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Plugin object API endpoint
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-id"></div>
+
+      .. _ansible_collections.networktocode.nautobot.plugin_module__parameter-id:
+
+      .. rst-class:: ansible-option-title
+
+      **id**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-id" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`dictionary` / :ansible-option-required:`required`
+
+      :ansible-option-versionadded:`added in networktocode.nautobot 4.4.0`
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Plugin object identifier(s) like name, slug, etc.
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-plugin"></div>
+
+      .. _ansible_collections.networktocode.nautobot.plugin_module__parameter-plugin:
+
+      .. rst-class:: ansible-option-title
+
+      **plugin**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-plugin" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string` / :ansible-option-required:`required`
+
+      :ansible-option-versionadded:`added in networktocode.nautobot 4.4.0`
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Plugin API base url
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-query_params"></div>
+
+      .. _ansible_collections.networktocode.nautobot.plugin_module__parameter-query_params:
+
+      .. rst-class:: ansible-option-title
+
+      **query_params**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-query_params" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`list` / :ansible-option-elements:`elements=string`
+
+      :ansible-option-versionadded:`added in networktocode.nautobot 3.0.0`
+
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      This can be used to override the specified values in ALLOWED\_QUERY\_PARAMS that is defined
+
+      in plugins/module\_utils/utils.py and provides control to users on what may make
+
+      an object unique in their environment.
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-state"></div>
+
+      .. _ansible_collections.networktocode.nautobot.plugin_module__parameter-state:
+
+      .. rst-class:: ansible-option-title
+
+      **state**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-state" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Use \ :literal:`present`\  or \ :literal:`absent`\  for adding or removing.
+
+
+      .. rst-class:: ansible-option-line
+
+      :ansible-option-choices:`Choices:`
+
+      - :ansible-option-choices-entry:`"absent"`
+      - :ansible-option-choices-entry-default:`"present"` :ansible-option-choices-default-mark:`← (default)`
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-token"></div>
+
+      .. _ansible_collections.networktocode.nautobot.plugin_module__parameter-token:
+
+      .. rst-class:: ansible-option-title
+
+      **token**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-token" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string` / :ansible-option-required:`required`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      The token created within Nautobot to authorize API access
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-url"></div>
+
+      .. _ansible_collections.networktocode.nautobot.plugin_module__parameter-url:
+
+      .. rst-class:: ansible-option-title
+
+      **url**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-url" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string` / :ansible-option-required:`required`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      The URL of the Nautobot instance resolvable by the Ansible host (for example: http://nautobot.example.com:8000)
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-validate_certs"></div>
+
+      .. _ansible_collections.networktocode.nautobot.plugin_module__parameter-validate_certs:
+
+      .. rst-class:: ansible-option-title
+
+      **validate_certs**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-validate_certs" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`any`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      If \ :literal:`no`\ , SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
+
+
+      .. rst-class:: ansible-option-line
+
+      :ansible-option-default-bold:`Default:` :ansible-option-default:`true`
+
+      .. raw:: html
+
+        </div>
+
+
+.. Attributes
+
+
+.. Notes
+
+Notes
+-----
+
+.. note::
+   - Task must have defined plugin base api url and object endpoint
+
+.. Seealso
+
+
+.. Examples
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: "Test Nautobot Plugin Module"
+      connection: local
+      hosts: localhost
+      gather_facts: False
+      tasks:
+        - name: Create LCM CVE
+          networktocode.nautobot.plugin:
+            url: http://nautobot.local
+            token: thisIsMyToken
+            plugin: nautobot-device-lifecycle-mgmt
+            endpoint: cve
+            id:
+              name: CVE-2020-7777
+            attrs:
+              published_date: 2020-09-25
+              link: https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory
+            state: present
+
+        - name: Modify LCM CVE
+          networktocode.nautobot.plugin:
+            url: http://nautobot.local
+            token: thisIsMyToken
+            plugin: nautobot-device-lifecycle-mgmt
+            endpoint: cve
+            id:
+              name: CVE-2020-7777
+            attrs:
+              published_date: 2020-09-25
+              link: https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/12345678
+            state: present
+
+        - name: Delete LCM CVE
+          networktocode.nautobot.plugin:
+            url: http://nautobot.local
+            token: thisIsMyToken
+            plugin: nautobot-device-lifecycle-mgmt
+            endpoint: cve
+            id:
+              name: CVE-2020-7777
+            state: absent
+
+        - name: Create GC compliance-feature
+          networktocode.nautobot.plugin:
+            url: http://nautobot.local
+            token: thisIsMyToken
+            plugin: golden-config
+            endpoint: compliance-feature
+            id:
+              name: AAA
+            attrs:
+              description: "Authentication Administration Accounting"
+            state: present
+            
+        - name: Create FW address-object
+          networktocode.nautobot.plugin:
+            url: http://nautobot.local
+            token: thisIsMyToken
+            plugin: firewall
+            endpoint: address-object
+            id:
+              name: access-point
+            attrs:
+              ip_address:
+                address: 10.0.0.0/32
+            state: present
+
+        - name: Delete FW address-object
+          networktocode.nautobot.plugin:
+            url: http://nautobot.local
+            token: thisIsMyToken
+            plugin: firewall
+            endpoint: address-object
+            id:
+              name: access-point
+            state: absent
+
+
+
+
+.. Facts
+
+
+.. Return values
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. rst-class:: ansible-option-table
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Key
+    - Description
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="return-endpoint"></div>
+
+      .. _ansible_collections.networktocode.nautobot.plugin_module__return-endpoint:
+
+      .. rst-class:: ansible-option-title
+
+      **endpoint**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#return-endpoint" title="Permalink to this return value"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`dictionary`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Serialized object as created/existent/updated/deleted within Nautobot
+
+
+      .. rst-class:: ansible-option-line
+
+      :ansible-option-returned-bold:`Returned:` always
+
+
+      .. raw:: html
+
+        </div>
+
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="return-msg"></div>
+
+      .. _ansible_collections.networktocode.nautobot.plugin_module__return-msg:
+
+      .. rst-class:: ansible-option-title
+
+      **msg**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#return-msg" title="Permalink to this return value"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-type:`string`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Message indicating failure or info about what has been achieved
+
+
+      .. rst-class:: ansible-option-line
+
+      :ansible-option-returned-bold:`Returned:` always
+
+
+      .. raw:: html
+
+        </div>
+
+
+
+..  Status (Presently only deprecated)
+
+
+.. Authors
+
+Authors
+~~~~~~~
+
+- Network to Code (@networktocode)
+- Patryk Szulczewski (@pszulczewski)
+
+
+
+.. Extra links
+
+Collection links
+~~~~~~~~~~~~~~~~
+
+.. raw:: html
+
+  <p class="ansible-links">
+    <a href="https://github.com/nautobot/nautobot-ansible/issues" aria-role="button" target="_blank" rel="noopener external">Issue Tracker</a>
+    <a href="https://github.com/nautobot/nautobot-ansible" aria-role="button" target="_blank" rel="noopener external">Repository (Sources)</a>
+  </p>
+
+.. Parsing errors
+

--- a/docs/plugins/plugin_module.rst
+++ b/docs/plugins/plugin_module.rst
@@ -218,17 +218,23 @@ Parameters
   * - .. raw:: html
 
         <div class="ansible-option-cell">
-        <div class="ansibleOptionAnchor" id="parameter-id"></div>
+        <div class="ansibleOptionAnchor" id="parameter-identifiers"></div>
+        <div class="ansibleOptionAnchor" id="parameter-ids"></div>
 
-      .. _ansible_collections.networktocode.nautobot.plugin_module__parameter-id:
+      .. _ansible_collections.networktocode.nautobot.plugin_module__parameter-identifiers:
+      .. _ansible_collections.networktocode.nautobot.plugin_module__parameter-ids:
 
       .. rst-class:: ansible-option-title
 
-      **id**
+      **identifiers**
 
       .. raw:: html
 
-        <a class="ansibleOptionLink" href="#parameter-id" title="Permalink to this option"></a>
+        <a class="ansibleOptionLink" href="#parameter-identifiers" title="Permalink to this option"></a>
+
+      .. rst-class:: ansible-option-type-line
+
+      :ansible-option-aliases:`aliases: ids`
 
       .. rst-class:: ansible-option-type-line
 
@@ -512,7 +518,7 @@ Examples
             token: thisIsMyToken
             plugin: nautobot-device-lifecycle-mgmt
             endpoint: cve
-            id:
+            identifiers:
               name: CVE-2020-7777
             attrs:
               published_date: 2020-09-25
@@ -525,7 +531,7 @@ Examples
             token: thisIsMyToken
             plugin: nautobot-device-lifecycle-mgmt
             endpoint: cve
-            id:
+            identifiers:
               name: CVE-2020-7777
             attrs:
               published_date: 2020-09-25
@@ -538,7 +544,7 @@ Examples
             token: thisIsMyToken
             plugin: nautobot-device-lifecycle-mgmt
             endpoint: cve
-            id:
+            identifiers:
               name: CVE-2020-7777
             state: absent
 
@@ -548,7 +554,7 @@ Examples
             token: thisIsMyToken
             plugin: golden-config
             endpoint: compliance-feature
-            id:
+            ids:
               name: AAA
             attrs:
               description: "Authentication Administration Accounting"
@@ -560,7 +566,7 @@ Examples
             token: thisIsMyToken
             plugin: firewall
             endpoint: address-object
-            id:
+            ids:
               name: access-point
             attrs:
               ip_address:
@@ -573,7 +579,7 @@ Examples
             token: thisIsMyToken
             plugin: firewall
             endpoint: address-object
-            id:
+            ids:
               name: access-point
             state: absent
 

--- a/plugins/module_utils/plugins.py
+++ b/plugins/module_utils/plugins.py
@@ -18,13 +18,13 @@ class NautobotPluginModule(NautobotModule):
         data = self.data
         plugin_name = self.data["plugin"]
         endpoint_name = data["endpoint"]
-        object_name = ", ".join(f"{key}:{value}" for key, value in self.data["id"].items())
+        object_name = ", ".join(f"{key}:{value}" for key, value in self.data["identifiers"].items())
 
         plugins_api = getattr(self.nb, self.endpoint)
         plugin_app = getattr(plugins_api, plugin_name)
         plugin_endpoint = getattr(plugin_app, endpoint_name)
 
-        query_params = self.module.params.get("id")
+        query_params = self.module.params.get("identifiers")
         self.nb_object = self._nb_endpoint_get(plugin_endpoint, query_params, plugin_name)
 
         if self.module.params.get("attrs"):

--- a/plugins/module_utils/plugins.py
+++ b/plugins/module_utils/plugins.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2023, NTC (@networktocode) <info@networktocode.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import NautobotModule
+
+
+class NautobotPluginModule(NautobotModule):
+    def run(self):
+        """
+        This function should have all necessary code for endpoints within the plugin application
+        to create/update/delete the endpoint objects.
+        """
+        self.result = {"changed": False}
+        data = self.data
+        plugin_name = self.data["plugin"]
+        endpoint_name = data["endpoint"]
+        object_name = self.data["id"]
+
+        plugins_api = getattr(self.nb, self.endpoint)
+        plugin_app = getattr(plugins_api, plugin_name)
+        plugin_endpoint = getattr(plugin_app, endpoint_name)
+
+        query_params = self.module.params.get("id")
+        self.nb_object = self._nb_endpoint_get(plugin_endpoint, query_params, plugin_name)
+
+        if self.module.params.get("attrs"):
+            query_params.update(self.module.params["attrs"])
+        if self.state == "present":
+            self._ensure_object_exists(plugin_endpoint, endpoint_name, object_name, query_params)
+        elif self.state == "absent":
+            self._ensure_object_absent(endpoint_name, object_name)
+
+        try:
+            serialized_object = self.nb_object.serialize()
+        except AttributeError:
+            serialized_object = self.nb_object
+
+        self.result[endpoint_name] = serialized_object
+
+        self.module.exit_json(**self.result)

--- a/plugins/module_utils/plugins.py
+++ b/plugins/module_utils/plugins.py
@@ -18,7 +18,7 @@ class NautobotPluginModule(NautobotModule):
         data = self.data
         plugin_name = self.data["plugin"]
         endpoint_name = data["endpoint"]
-        object_name = self.data["id"]
+        object_name = ", ".join(f"{key}:{value}" for key, value in self.data["id"].items())
 
         plugins_api = getattr(self.nb, self.endpoint)
         plugin_app = getattr(plugins_api, plugin_name)

--- a/plugins/modules/plugin.py
+++ b/plugins/modules/plugin.py
@@ -34,7 +34,8 @@ options:
     required: true
     type: str
     version_added: "4.4.0"
-  id:
+  identifiers:
+    aliases: [ids]
     description:
       - Plugin object identifier(s) like name, slug, etc.
     required: true
@@ -60,7 +61,7 @@ EXAMPLES = r"""
         token: thisIsMyToken
         plugin: nautobot-device-lifecycle-mgmt
         endpoint: cve
-        id:
+        identifiers:
           name: CVE-2020-7777
         attrs:
           published_date: 2020-09-25
@@ -73,7 +74,7 @@ EXAMPLES = r"""
         token: thisIsMyToken
         plugin: nautobot-device-lifecycle-mgmt
         endpoint: cve
-        id:
+        identifiers:
           name: CVE-2020-7777
         attrs:
           published_date: 2020-09-25
@@ -86,7 +87,7 @@ EXAMPLES = r"""
         token: thisIsMyToken
         plugin: nautobot-device-lifecycle-mgmt
         endpoint: cve
-        id:
+        identifiers:
           name: CVE-2020-7777
         state: absent
 
@@ -96,7 +97,7 @@ EXAMPLES = r"""
         token: thisIsMyToken
         plugin: golden-config
         endpoint: compliance-feature
-        id:
+        ids:
           name: AAA
         attrs:
           description: "Authentication Administration Accounting"
@@ -108,7 +109,7 @@ EXAMPLES = r"""
         token: thisIsMyToken
         plugin: firewall
         endpoint: address-object
-        id:
+        ids:
           name: access-point
         attrs:
           ip_address:
@@ -121,7 +122,7 @@ EXAMPLES = r"""
         token: thisIsMyToken
         plugin: firewall
         endpoint: address-object
-        id:
+        ids:
           name: access-point
         state: absent
 """
@@ -154,14 +155,14 @@ def main():
         dict(
             plugin=dict(required=True, type="str"),
             endpoint=dict(required=True, type="str"),
-            id=dict(required=True, type="dict"),
+            identifiers=dict(required=True, type="dict", aliases=["ids"]),
             attrs=dict(required=False, type="dict"),
         )
     )
 
     required_if = [
-        ("state", "present", ["plugin", "endpoint", "id"]),
-        ("state", "absent", ["plugin", "endpoint", "id"]),
+        ("state", "present", ["plugin", "endpoint", "identifiers"]),
+        ("state", "absent", ["plugin", "endpoint", "identifiers"]),
     ]
 
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)

--- a/plugins/modules/plugin.py
+++ b/plugins/modules/plugin.py
@@ -160,12 +160,7 @@ def main():
         )
     )
 
-    required_if = [
-        ("state", "present", ["plugin", "endpoint", "identifiers"]),
-        ("state", "absent", ["plugin", "endpoint", "identifiers"]),
-    ]
-
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     plugin = NautobotPluginModule(module, "plugins")
     plugin.run()

--- a/plugins/modules/plugin.py
+++ b/plugins/modules/plugin.py
@@ -1,0 +1,174 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2020, Network to Code (@networktocode) <info@networktocode.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: plugin
+short_description: CRUD operation on plugin objects
+description:
+  - Creates, removes or updates various plugin objects in Nautobot
+notes:
+  - Task must have defined plugin base api url and object endpoint
+author:
+  - Network to Code (@networktocode)
+  - Patryk Szulczewski (@pszulczewski)
+version_added: "4.4.0"
+extends_documentation_fragment:
+  - networktocode.nautobot.fragments.base
+options:
+  plugin:
+    description:
+      - Plugin API base url
+    required: true
+    type: str
+    version_added: "4.4.0"
+  endpoint:
+    description:
+      - Plugin object API endpoint
+    required: true
+    type: str
+    version_added: "4.4.0"
+  id:
+    description:
+      - Plugin object identifier(s) like name, slug, etc.
+    required: true
+    type: dict
+    version_added: "4.4.0"
+  attrs:
+    description:
+      - Object attributes other than identifier to create or update an object, like description, etc.
+    required: false
+    type: dict
+    version_added: "4.4.0"
+"""
+
+EXAMPLES = r"""
+- name: "Test Nautobot Plugin Module"
+  connection: local
+  hosts: localhost
+  gather_facts: False
+  tasks:
+    - name: Create LCM CVE
+      networktocode.nautobot.plugin:
+        url: http://nautobot.local
+        token: thisIsMyToken
+        plugin: nautobot-device-lifecycle-mgmt
+        endpoint: cve
+        id:
+          name: CVE-2020-7777
+        attrs:
+          published_date: 2020-09-25
+          link: https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory
+        state: present
+
+    - name: Modify LCM CVE
+      networktocode.nautobot.plugin:
+        url: http://nautobot.local
+        token: thisIsMyToken
+        plugin: nautobot-device-lifecycle-mgmt
+        endpoint: cve
+        id:
+          name: CVE-2020-7777
+        attrs:
+          published_date: 2020-09-25
+          link: https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/12345678
+        state: present
+
+    - name: Delete LCM CVE
+      networktocode.nautobot.plugin:
+        url: http://nautobot.local
+        token: thisIsMyToken
+        plugin: nautobot-device-lifecycle-mgmt
+        endpoint: cve
+        id:
+          name: CVE-2020-7777
+        state: absent
+
+    - name: Create GC compliance-feature
+      networktocode.nautobot.plugin:
+        url: http://nautobot.local
+        token: thisIsMyToken
+        plugin: golden-config
+        endpoint: compliance-feature
+        id:
+          name: AAA
+        attrs:
+          description: "Authentication Administration Accounting"
+        state: present
+        
+    - name: Create FW address-object
+      networktocode.nautobot.plugin:
+        url: http://nautobot.local
+        token: thisIsMyToken
+        plugin: firewall
+        endpoint: address-object
+        id:
+          name: access-point
+        attrs:
+          ip_address:
+            address: 10.0.0.0/32
+        state: present
+
+    - name: Delete FW address-object
+      networktocode.nautobot.plugin:
+        url: http://nautobot.local
+        token: thisIsMyToken
+        plugin: firewall
+        endpoint: address-object
+        id:
+          name: access-point
+        state: absent
+"""
+
+RETURN = r"""
+endpoint:
+  description: Serialized object as created/existent/updated/deleted within Nautobot
+  returned: always
+  type: dict
+msg:
+  description: Message indicating failure or info about what has been achieved
+  returned: always
+  type: str
+"""
+
+from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import NAUTOBOT_ARG_SPEC
+from ansible_collections.networktocode.nautobot.plugins.module_utils.plugins import (
+    NautobotPluginModule,
+)
+from ansible.module_utils.basic import AnsibleModule
+from copy import deepcopy
+
+
+def main():
+    """
+    Main entry point for module execution
+    """
+    argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
+    argument_spec.update(
+        dict(
+            plugin=dict(required=True, type="str"),
+            endpoint=dict(required=True, type="str"),
+            id=dict(required=True, type="dict"),
+            attrs=dict(required=False, type="dict"),
+        )
+    )
+
+    required_if = [
+        ("state", "present", ["plugin", "endpoint", "id"]),
+        ("state", "absent", ["plugin", "endpoint", "id"]),
+    ]
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
+
+    plugin = NautobotPluginModule(module, "plugins")
+    plugin.run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tasks.py
+++ b/tasks.py
@@ -91,27 +91,6 @@ def run_command(context, command, **kwargs):
 
 
 # ------------------------------------------------------------------------------
-# BUILD
-# ------------------------------------------------------------------------------
-@task(
-    help={
-        "force_rm": "Always remove intermediate containers",
-        "cache": "Whether to use Docker's cache when building the image (defaults to enabled)",
-    }
-)
-def build(context, force_rm=False, cache=True):
-    """Build Nautobot docker image."""
-    command = "build"
-
-    if not cache:
-        command += " --no-cache"
-    if force_rm:
-        command += " --force-rm"
-
-    print(f"Building Nautobot {context.nautobot_ansible.nautobot_ver} with Python {context.nautobot_ansible.python_ver}...")
-    docker_compose(context, command)
-
-# ------------------------------------------------------------------------------
 # START / STOP / DEBUG
 # ------------------------------------------------------------------------------
 @task

--- a/tasks.py
+++ b/tasks.py
@@ -91,6 +91,27 @@ def run_command(context, command, **kwargs):
 
 
 # ------------------------------------------------------------------------------
+# BUILD
+# ------------------------------------------------------------------------------
+@task(
+    help={
+        "force_rm": "Always remove intermediate containers",
+        "cache": "Whether to use Docker's cache when building the image (defaults to enabled)",
+    }
+)
+def build(context, force_rm=False, cache=True):
+    """Build Nautobot docker image."""
+    command = "build"
+
+    if not cache:
+        command += " --no-cache"
+    if force_rm:
+        command += " --force-rm"
+
+    print(f"Building Nautobot {context.nautobot_ansible.nautobot_ver} with Python {context.nautobot_ansible.python_ver}...")
+    docker_compose(context, command)
+
+# ------------------------------------------------------------------------------
 # START / STOP / DEBUG
 # ------------------------------------------------------------------------------
 @task

--- a/tests/integration/targets/latest/tasks/main.yml
+++ b/tests/integration/targets/latest/tasks/main.yml
@@ -511,3 +511,12 @@
         - relationship_association
   tags:
     - relationship_association
+
+- name: "PYNAUTOBOT_PLUGIN_BGP_ASN_TESTS"
+  include_tasks:
+    file: "plugin_bgp_asn.yml"
+    apply:
+      tags:
+        - plugin_bgp_ans
+  tags:
+    - plugin_bgp_ans

--- a/tests/integration/targets/latest/tasks/main.yml
+++ b/tests/integration/targets/latest/tasks/main.yml
@@ -517,6 +517,6 @@
     file: "plugin_bgp_asn.yml"
     apply:
       tags:
-        - plugin_bgp_ans
+        - plugin_bgp_asn
   tags:
-    - plugin_bgp_ans
+    - plugin_bgp_asn

--- a/tests/integration/targets/latest/tasks/plugin_bgp_asn.yml
+++ b/tests/integration/targets/latest/tasks/plugin_bgp_asn.yml
@@ -10,7 +10,7 @@
     token: "{{ nautobot_token }}"
     plugin: bgp
     endpoint: autonomous-systems
-    id:
+    ids:
       asn: 65001
     attrs:
       status: active
@@ -33,7 +33,7 @@
     token: "{{ nautobot_token }}"
     plugin: bgp
     endpoint: autonomous-systems
-    id:
+    ids:
       asn: 65001
     attrs:
       status: active
@@ -54,7 +54,7 @@
     token: "{{ nautobot_token }}"
     plugin: bgp
     endpoint: autonomous-systems
-    id:
+    ids:
       asn: 65001
     attrs:
       status: planned
@@ -75,7 +75,7 @@
     token: "{{ nautobot_token }}"
     plugin: bgp
     endpoint: autonomous-systems
-    id:
+    ids:
       asn: 65001
     attrs:
       status: planned
@@ -94,7 +94,7 @@
     token: "{{ nautobot_token }}"
     plugin: bgp
     endpoint: autonomous-systems
-    id:
+    ids:
       asn: 65001
     state: absent
   register: test_five
@@ -113,7 +113,7 @@
     token: "{{ nautobot_token }}"
     plugin: bgp
     endpoint: autonomous-systems
-    id:
+    ids:
       asn: 65001
     state: absent
   register: test_six

--- a/tests/integration/targets/latest/tasks/plugin_bgp_asn.yml
+++ b/tests/integration/targets/latest/tasks/plugin_bgp_asn.yml
@@ -1,0 +1,89 @@
+---
+##
+##
+### PYNAUTOBOT_PLUGIN_BGP_ASN
+##
+##
+- name: "BGP ASN 1: Creation"
+  networktocode.nautobot.plugin:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    plugin: bgp
+    endpoint: autonomous-systems
+    id:
+      asn: 65001
+    attrs:
+      status: active
+    state: present
+  register: test_one
+
+- name: "BGP ASN 1: ASSERT - Creation"
+  assert:
+    that:
+      - test_one is changed
+      - test_one['diff']['before']['state'] == "absent"
+      - test_one['diff']['after']['state'] == "present"
+      - test_one['autonomous-systems']['asn'] == 65001
+      - test_one['autonomous-systems']['status'] == "active"
+      - test_one['msg'] == "autonomous-systems asn:65001 created"
+
+- name: "BGP ASN 2: Create duplicate"
+  networktocode.nautobot.plugin:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    plugin: bgp
+    endpoint: autonomous-systems
+    id:
+      asn: 65001
+    attrs:
+      status: active
+    state: present
+  register: test_two
+
+- name: "BGP ASN 2: ASSERT - Create duplicate"
+  assert:
+    that:
+      - test_two is not changed
+      - test_two['autonomous-systems']['asn'] == 65001
+      - test_two['autonomous-systems']['status'] == "active"
+      - test_two['msg'] == "autonomous-systems asn:65001 already exists"
+
+- name: "BGP ASN 3: Update"
+  networktocode.nautobot.plugin:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    plugin: bgp
+    endpoint: autonomous-systems
+    id:
+      asn: 65001
+    attrs:
+      status: planned
+    state: present
+  register: test_three
+
+- name: "BGP ASN 3: ASSERT - Updated"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['before']['status'] == "active"
+      - test_three['diff']['after']['status'] == "planned"
+      - test_three['msg'] == "autonomous-systems asn:65001 updated"
+
+- name: "BGP ASN 4: Delete"
+  networktocode.nautobot.plugin:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    plugin: bgp
+    endpoint: autonomous-systems
+    id:
+      asn: 65001
+    state: absent
+  register: test_four
+
+- name: "BGP ASN 4: ASSERT - Delete"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "present"
+      - test_four['diff']['after']['state'] == "absent"
+      - test_four['msg'] == "autonomous-systems asn:65001 deleted"

--- a/tests/integration/targets/latest/tasks/plugin_bgp_asn.yml
+++ b/tests/integration/targets/latest/tasks/plugin_bgp_asn.yml
@@ -69,7 +69,26 @@
       - test_three['diff']['after']['status'] == "planned"
       - test_three['msg'] == "autonomous-systems asn:65001 updated"
 
-- name: "BGP ASN 4: Delete"
+- name: "BGP ASN 4: Update Idempotent"
+  networktocode.nautobot.plugin:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    plugin: bgp
+    endpoint: autonomous-systems
+    id:
+      asn: 65001
+    attrs:
+      status: planned
+    state: present
+  register: test_four
+
+- name: "BGP ASN 4: ASSERT - Update Idempotent"
+  assert:
+    that:
+      - test_four is not changed
+      - test_four['msg'] == "autonomous-systems asn:65001 already exists"
+
+- name: "BGP ASN 5: Delete"
   networktocode.nautobot.plugin:
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
@@ -78,12 +97,29 @@
     id:
       asn: 65001
     state: absent
-  register: test_four
+  register: test_five
 
-- name: "BGP ASN 4: ASSERT - Delete"
+- name: "BGP ASN 5: ASSERT - Delete"
   assert:
     that:
-      - test_four is changed
-      - test_four['diff']['before']['state'] == "present"
-      - test_four['diff']['after']['state'] == "absent"
-      - test_four['msg'] == "autonomous-systems asn:65001 deleted"
+      - test_five is changed
+      - test_five['diff']['before']['state'] == "present"
+      - test_five['diff']['after']['state'] == "absent"
+      - test_five['msg'] == "autonomous-systems asn:65001 deleted"
+
+- name: "BGP ASN 6: Delete non-existing"
+  networktocode.nautobot.plugin:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    plugin: bgp
+    endpoint: autonomous-systems
+    id:
+      asn: 65001
+    state: absent
+  register: test_six
+
+- name: "BGP ASN 6: ASSERT - non-existing"
+  assert:
+    that:
+      - test_six is not changed
+      - test_six['msg'] == "autonomous-systems asn:65001 already absent"


### PR DESCRIPTION
Proposal of dynamic plugins module.

This approach for plugins is slightly different than nautobot core modules, which have all endpoints statically added in the code. Looking at the variety of plugins/apps ecosystem I think that following the same patterns for plugins endpoints (a module for each endpoint) would be impractical, tedious to develop and hard to maintain in the future.

This proposal assumes that, `plugin`(plugin `base_url`), `endpoint` and object attributes are given in by users in ansible playbook task. Object attributes are split into two module args:
1) `id` where object identifiers like name, slug etc. for `endpoint.get(**id)` are given as k:v pairs
2) `attrs` where extra k:v pairs are given for creating or updating an object

Error handling is done by backend `pynautobot` and error message is returned in ansible task `msg` key.

Still TODO if these modules are welcomed:
- [x] Extend d-compose nautobot with a plugin.
- [x] Add integration test for the module.