### PR TITLE
Fixes and enables testing for Nautobot 1.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 ---
 name: "CI"
+concurrency:  # Cancel any existing runs of this workflow for this same PR
+  group: "${{ '{{ github.workflow }}' }}-${{ '{{ github.ref }}' }}"
+  cancel-in-progress: true
 on: # yamllint disable
   push:
     branches:
@@ -8,147 +11,7 @@ on: # yamllint disable
   pull_request:
   release:
     types: [published]
-  schedule:
-    - cron: "20 3 * * 1"
 
 jobs:
-  lint:
-    runs-on: "ubuntu-20.04"
-    steps:
-      - name: "Check out repository code"
-        uses: "actions/checkout@v3"
-      - name: "Install invoke"
-        run: "pip install -U pip && pip install invoke"
-      - name: "Linting"
-        run: "invoke lint"
-  test:
-    runs-on: "ubuntu-20.04"
-    strategy:
-      fail-fast: true
-      matrix:
-        # Add 3.6 back once we fix the sanity decode issue
-        python-version: ["3.7", "3.8", "3.9"]
-    env:
-      INVOKE_NAUTOBOT_ANSIBLE_PYTHON_VER: "${{ matrix.python-version }}"
-    steps:
-      - name: "Check out repository code"
-        uses: "actions/checkout@v3"
-      - name: "Install invoke"
-        run: "pip install -U pip && pip install invoke"
-      - name: "Tests"
-        run: "invoke unit"
-    needs:
-      - "lint"
-  integration:
-    runs-on: "ubuntu-20.04"
-    strategy:
-      fail-fast: false
-      matrix:
-        # Need to check what is needed for the integration step
-        # python-version: ["3.6", "3.7", "3.8", "3.9"]
-        # nautobot-version: ["1.0.3", "1.1.1"]
-        # ansible-release: ["base", "core"]
-        include:
-          - python-version: "3.8"
-            nautobot-version: "1.3"
-            ansible-release: "base"  # Ansible 2.10
-          - python-version: "3.8"
-            nautobot-version: "1.3"
-            ansible-release: "2.11"
-          - python-version: "3.8"
-            nautobot-version: "1.3"
-            ansible-release: "2.9"
-          - python-version: "3.8"
-            nautobot-version: "1.4"
-            ansible-release: "2.10"
-          - python-version: "3.8"
-            nautobot-version: "1.4"
-            ansible-release: "2.12"
-          # - python-version: "3.8"
-          #   nautobot-version: "1.5"
-          #   ansible-release: "2.12"
-    env:
-      INVOKE_NAUTOBOT_ANSIBLE_PYTHON_VER: "${{ matrix.python-version }}"
-      INVOKE_NAUTOBOT_ANSIBLE_NAUTOBOT_VER: "${{ matrix.nautobot-version }}"
-    steps:
-      - name: "Check out repository code"
-        uses: "actions/checkout@v3"
-      - name: "Install invoke"
-        run: "pip install -U pip && pip install invoke"
-      - name: "Install poetry"
-        if: "${{ matrix.ansible-release == '2.11' }}"
-        run: "curl -sSL https://install.python-poetry.org | python3 -"
-      - name: "Remove ansible-base"
-        if: "${{ matrix.ansible-release == '2.11' }}"
-        run: "poetry remove ansible-base"
-      - name: "Add ansible-core"
-        if: "${{ matrix.ansible-release == '2.11' }}"
-        run: "poetry add ansible-core@~2.11"
-      - name: "Install poetry"
-        if: "${{ matrix.ansible-release == '2.9' }}"
-        run: "curl -sSL https://install.python-poetry.org | python3 -"
-      - name: "Remove ansible-base"
-        if: "${{ matrix.ansible-release == '2.9' }}"
-        run: "poetry remove ansible-base"
-      - name: "Add Ansible 2.9"
-        if: "${{ matrix.ansible-release == '2.9' }}"
-        run: "poetry add ansible@~2.9"
-      - name: "Install poetry"
-        if: "${{ matrix.ansible-release == '2.12' }}"
-        run: "curl -sSL https://install.python-poetry.org | python3 -"
-      - name: "Remove ansible-base"
-        if: "${{ matrix.ansible-release == '2.12' }}"
-        run: "poetry remove ansible-base"
-      - name: "Add Ansible 2.12"
-        if: "${{ matrix.ansible-release == '2.12' }}"
-        run: "poetry add ansible-core@~2.12 --python ^${{ matrix.python-version }}"
-      - name: "Start containers"
-        run: "invoke start"
-      - name: "Tests"
-        run: "invoke integration"
-    needs:
-      - "test"
-  publish_github:
-    name: "Publish to GitHub"
-    runs-on: "ubuntu-20.04"
-    if: "startsWith(github.ref, 'refs/tags/v')"
-    steps:
-      - name: "Check out repository code"
-        uses: "actions/checkout@v3"
-      - name: "Set up Python"
-        uses: "actions/setup-python@v2"
-        with:
-          python-version: "3.9"
-      - name: "Install Python Packages"
-        run: "pip install ansible-core"
-      - name: "Build the collection"
-        run: "ansible-galaxy collection build --output-path build"
-      - name: "Upload binaries to release"
-        uses: "svenstaro/upload-release-action@v2"
-        with:
-          repo_token: "${{ secrets.NTC_GITHUB_TOKEN }}"
-          file: "build/*"
-          tag: "${{ github.ref }}"
-          overwrite: true
-          file_glob: true
-    needs:
-      - "integration"
-  publish_galaxy:
-    name: "Publish to Ansible Galaxy"
-    runs-on: "ubuntu-20.04"
-    if: "startsWith(github.ref, 'refs/tags/v')"
-    steps:
-      - name: "Check out repository code"
-        uses: "actions/checkout@v3"
-      - name: "Set up Python"
-        uses: "actions/setup-python@v2"
-        with:
-          python-version: "3.9"
-      - name: "Install Python Packages"
-        run: "pip install ansible-core"
-      - name: "Build the collection"
-        run: "ansible-galaxy collection build --output-path build"
-      - name: "Publish the collection"
-        run: "ansible-galaxy collection publish build/* --api-key=${{ secrets.GALAXY_API_TOKEN }}"
-    needs:
-      - "integration"
+  ci:
+    uses: ./.github/workflows/jobs.yml

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -1,0 +1,145 @@
+---
+name: "Jobs"
+on: # yamllint disable
+  workflow_call:
+
+jobs:
+  lint:
+    runs-on: "ubuntu-20.04"
+    steps:
+      - name: "Check out repository code"
+        uses: "actions/checkout@v3"
+      - name: "Install invoke"
+        run: "pip install -U pip && pip install invoke"
+      - name: "Linting"
+        run: "invoke lint"
+  unit:
+    runs-on: "ubuntu-20.04"
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.7", "3.8", "3.9"]
+    env:
+      INVOKE_NAUTOBOT_ANSIBLE_PYTHON_VER: "${{ matrix.python-version }}"
+    steps:
+      - name: "Check out repository code"
+        uses: "actions/checkout@v3"
+      - name: "Install invoke"
+        run: "pip install -U pip && pip install invoke"
+      - name: "Tests"
+        run: "invoke unit"
+    needs:
+      - "lint"
+  integration:
+    runs-on: "ubuntu-20.04"
+    strategy:
+      fail-fast: false
+      matrix:
+        # Need to check what is needed for the integration step
+        # python-version: ["3.6", "3.7", "3.8", "3.9"]
+        # nautobot-version: ["1.0.3", "1.1.1"]
+        # ansible-release: ["base", "core"]
+        include:
+          - python-version: "3.8"
+            nautobot-version: "1.3"
+            ansible-release: "base"  # Ansible 2.10
+          - python-version: "3.8"
+            nautobot-version: "1.3"
+            ansible-release: "2.11"
+          - python-version: "3.8"
+            nautobot-version: "1.3"
+            ansible-release: "2.9"
+          - python-version: "3.8"
+            nautobot-version: "1.4"
+            ansible-release: "2.10"
+          - python-version: "3.8"
+            nautobot-version: "1.4"
+            ansible-release: "2.12"
+          - python-version: "3.8"
+            nautobot-version: "1.5"
+            ansible-release: "2.12"
+    env:
+      INVOKE_NAUTOBOT_ANSIBLE_PYTHON_VER: "${{ matrix.python-version }}"
+      INVOKE_NAUTOBOT_ANSIBLE_NAUTOBOT_VER: "${{ matrix.nautobot-version }}"
+    steps:
+      - name: "Check out repository code"
+        uses: "actions/checkout@v3"
+      - name: "Install invoke"
+        run: "pip install -U pip && pip install invoke"
+      - name: "Install poetry"
+        if: "${{ matrix.ansible-release == '2.11' }}"
+        run: "curl -sSL https://install.python-poetry.org | python3 -"
+      - name: "Remove ansible-base"
+        if: "${{ matrix.ansible-release == '2.11' }}"
+        run: "poetry remove ansible-base"
+      - name: "Add ansible-core"
+        if: "${{ matrix.ansible-release == '2.11' }}"
+        run: "poetry add ansible-core@~2.11"
+      - name: "Install poetry"
+        if: "${{ matrix.ansible-release == '2.9' }}"
+        run: "curl -sSL https://install.python-poetry.org | python3 -"
+      - name: "Remove ansible-base"
+        if: "${{ matrix.ansible-release == '2.9' }}"
+        run: "poetry remove ansible-base"
+      - name: "Add Ansible 2.9"
+        if: "${{ matrix.ansible-release == '2.9' }}"
+        run: "poetry add ansible@~2.9"
+      - name: "Install poetry"
+        if: "${{ matrix.ansible-release == '2.12' }}"
+        run: "curl -sSL https://install.python-poetry.org | python3 -"
+      - name: "Remove ansible-base"
+        if: "${{ matrix.ansible-release == '2.12' }}"
+        run: "poetry remove ansible-base"
+      - name: "Add Ansible 2.12"
+        if: "${{ matrix.ansible-release == '2.12' }}"
+        run: "poetry add ansible-core@~2.12 --python ^${{ matrix.python-version }}"
+      - name: "Start containers"
+        run: "invoke start"
+      - name: "Tests"
+        run: "invoke integration"
+    needs:
+      - "unit"
+  publish_github:
+    name: "Publish to GitHub"
+    runs-on: "ubuntu-20.04"
+    if: "startsWith(github.ref, 'refs/tags/v')"
+    steps:
+      - name: "Check out repository code"
+        uses: "actions/checkout@v3"
+      - name: "Set up Python"
+        uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.9"
+      - name: "Install Python Packages"
+        run: "pip install ansible-core"
+      - name: "Build the collection"
+        run: "ansible-galaxy collection build --output-path build"
+      - name: "Upload binaries to release"
+        uses: "svenstaro/upload-release-action@v2"
+        with:
+          repo_token: "${{ secrets.NTC_GITHUB_TOKEN }}"
+          file: "build/*"
+          tag: "${{ github.ref }}"
+          overwrite: true
+          file_glob: true
+    needs:
+      - "integration"
+  publish_galaxy:
+    name: "Publish to Ansible Galaxy"
+    runs-on: "ubuntu-20.04"
+    if: "startsWith(github.ref, 'refs/tags/v')"
+    steps:
+      - name: "Check out repository code"
+        uses: "actions/checkout@v3"
+      - name: "Set up Python"
+        uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.9"
+      - name: "Install Python Packages"
+        run: "pip install ansible-core"
+      - name: "Build the collection"
+        run: "ansible-galaxy collection build --output-path build"
+      - name: "Publish the collection"
+        run: "ansible-galaxy collection publish build/* --api-key=${{ secrets.GALAXY_API_TOKEN }}"
+    needs:
+      - "integration"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,9 @@
+---
+name: "Scheduled CI"
+on: # yamllint disable
+  schedule:
+    - cron: "20 3 * * 1"
+
+jobs:
+  ci:
+    uses: ./.github/workflows/jobs.yml

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -3,6 +3,9 @@ ARG PYTHON_VER
 
 FROM ghcr.io/nautobot/nautobot:${NAUTOBOT_VER}-py${PYTHON_VER} as nautobot
 
+# Capture the argument again
+ARG NAUTOBOT_VER
+
 # Copy in the requirements file
 COPY ./development/requirements${NAUTOBOT_VER}.txt /opt/nautobot/requirements.txt
 

--- a/tasks.py
+++ b/tasks.py
@@ -24,7 +24,7 @@ namespace = Collection("nautobot_ansible")
 namespace.configure(
     {
         "nautobot_ansible": {
-            "nautobot_ver": "1.3.10",
+            "nautobot_ver": "1.5",
             "project_name": "nautobot_ansible",
             "python_ver": "3.7",
             "local": False,

--- a/tests/integration/entrypoint.sh
+++ b/tests/integration/entrypoint.sh
@@ -32,10 +32,10 @@ function main {
 
     echo "# Running..."
     # shellcheck disable=SC2086
-    if [[ "${NAUTOBOT_VER:-}" == "1.4" ]]; then
-      ansible-test integration $ANSIBLE_INTEGRATION_ARGS --coverage --python "$PYTHON_VERSION" inventory-1.4 "$@"
-    else
+    if [[ "${NAUTOBOT_VER:-}" == "1.3" ]]; then
       ansible-test integration $ANSIBLE_INTEGRATION_ARGS --coverage --python "$PYTHON_VERSION" inventory "$@"
+    else
+      ansible-test integration $ANSIBLE_INTEGRATION_ARGS --coverage --python "$PYTHON_VERSION" inventory-1.4 "$@"
     fi
     ansible-test integration $ANSIBLE_INTEGRATION_ARGS --coverage --python "$PYTHON_VERSION" regression-latest "$@"
     ansible-test integration $ANSIBLE_INTEGRATION_ARGS --coverage --python "$PYTHON_VERSION" latest "$@"

--- a/tests/integration/nautobot-populate.py
+++ b/tests/integration/nautobot-populate.py
@@ -17,7 +17,11 @@ from packaging import version
 nb_host = os.getenv("NAUTOBOT_URL", "http://nautobot:8000")
 nb_token = os.getenv("NAUTOBOT_TOKEN", "0123456789abcdef0123456789abcdef01234567")
 nb = pynautobot.api(nb_host, nb_token)
-nb_version = version.parse(nb.version)
+api_version = version.parse(nb.version)
+
+# Set the nautobot version for conditional population of data
+nb_status = nb.status()
+nautobot_version = version.parse(nb_status["nautobot-version"])
 
 ERRORS = False
 
@@ -95,9 +99,23 @@ created_sites = make_nautobot_calls(nb.dcim.sites, sites)
 test_site = nb.dcim.sites.get(slug="test-site")
 test_site2 = nb.dcim.sites.get(slug="test-site2")
 
-# Create location type
-location_types = [{"name": "My Location Type", "slug": "my-location-type", "nestable": True}]
-created_location_types = make_nautobot_calls(nb.dcim.location_types, location_types)
+# Locations are only available in Nautobot 1.4+
+if nautobot_version >= version.parse("1.4"):
+    # Create location types
+    location_types = [{"name": "My Parent Location Type", "slug": "my-parent-location-type", "nestable": True}]
+    created_location_types = make_nautobot_calls(nb.dcim.location_types, location_types)
+    parent_location_type = nb.dcim.location_types.get(slug="my-parent-location-type")
+
+    # Create child location types
+    child_location_types = [
+        {
+            "name": "My Child Location Type",
+            "slug": "my-child-location-type",
+            "nestable": True,
+            "parent": parent_location_type.id,
+        }
+    ]
+    created_child_location_types = make_nautobot_calls(nb.dcim.location_types, child_location_types)
 
 # Create power panel
 power_panels = [{"name": "Test Power Panel", "site": test_site.id}]
@@ -131,7 +149,14 @@ vlans = [
     {"name": "Wireless", "vid": 100, "site": test_site.id, "status": "active"},
     {"name": "Data", "vid": 200, "site": test_site.id, "status": "active"},
     {"name": "VoIP", "vid": 300, "site": test_site.id, "status": "active"},
-    {"name": "Test VLAN", "vid": 400, "site": test_site.id, "tenant": test_tenant.id, "group": test_vlan_group.id, "status": "active"},
+    {
+        "name": "Test VLAN",
+        "vid": 400,
+        "site": test_site.id,
+        "tenant": test_tenant.id,
+        "group": test_vlan_group.id,
+        "status": "active",
+    },
 ]
 created_vlans = make_nautobot_calls(nb.ipam.vlans, vlans)
 
@@ -157,8 +182,20 @@ arista_manu = nb.dcim.manufacturers.get(slug="arista")
 device_types = [
     {"model": "Cisco Test", "slug": "cisco-test", "manufacturer": cisco_manu.id},
     {"model": "Arista Test", "slug": "arista-test", "manufacturer": arista_manu.id},
-    {"model": "Nexus Parent", "slug": "nexus-parent", "u_height": 0, "manufacturer": cisco_manu.id, "subdevice_role": "parent"},
-    {"model": "Nexus Child", "slug": "nexus-child", "u_height": 0, "manufacturer": cisco_manu.id, "subdevice_role": "child"},
+    {
+        "model": "Nexus Parent",
+        "slug": "nexus-parent",
+        "u_height": 0,
+        "manufacturer": cisco_manu.id,
+        "subdevice_role": "parent",
+    },
+    {
+        "model": "Nexus Child",
+        "slug": "nexus-child",
+        "u_height": 0,
+        "manufacturer": cisco_manu.id,
+        "subdevice_role": "child",
+    },
     {"model": "1841", "slug": "1841", "manufacturer": cisco_manu.id},
 ]
 
@@ -223,10 +260,36 @@ devices = [
         "local_context_data": {"ntp_servers": ["pool.ntp.org"]},
         "status": "active",
     },
-    {"name": "TestDeviceR1", "device_type": cisco_test.id, "device_role": core_switch.id, "site": test_site.id, "rack": test_rack.id, "status": "active"},
-    {"name": "R1-Device", "device_type": cisco_test.id, "device_role": core_switch.id, "site": test_site2.id, "rack": test_rack_site2.id, "status": "active"},
-    {"name": "Test Nexus One", "device_type": nexus_parent.id, "device_role": core_switch.id, "site": test_site.id, "status": "active"},
-    {"name": "Test Nexus Child One", "device_type": nexus_child.id, "device_role": core_switch.id, "site": test_site.id, "status": "active"},
+    {
+        "name": "TestDeviceR1",
+        "device_type": cisco_test.id,
+        "device_role": core_switch.id,
+        "site": test_site.id,
+        "rack": test_rack.id,
+        "status": "active",
+    },
+    {
+        "name": "R1-Device",
+        "device_type": cisco_test.id,
+        "device_role": core_switch.id,
+        "site": test_site2.id,
+        "rack": test_rack_site2.id,
+        "status": "active",
+    },
+    {
+        "name": "Test Nexus One",
+        "device_type": nexus_parent.id,
+        "device_role": core_switch.id,
+        "site": test_site.id,
+        "status": "active",
+    },
+    {
+        "name": "Test Nexus Child One",
+        "device_type": nexus_child.id,
+        "device_role": core_switch.id,
+        "site": test_site.id,
+        "status": "active",
+    },
 ]
 created_devices = make_nautobot_calls(nb.dcim.devices, devices)
 # Device variables to be used later on
@@ -277,8 +340,18 @@ test100_gi2 = nb.dcim.interfaces.get(name="GigabitEthernet2", device_id=test100.
 
 # Create IP Addresses
 ip_addresses = [
-    {"address": "172.16.180.1/24", "assigned_object_type": "dcim.interface", "assigned_object_id": test100_gi1.id, "status": "active"},
-    {"address": "2001::1:1/64", "assigned_object_type": "dcim.interface", "assigned_object_id": test100_gi2.id, "status": "active"},
+    {
+        "address": "172.16.180.1/24",
+        "assigned_object_type": "dcim.interface",
+        "assigned_object_id": test100_gi1.id,
+        "status": "active",
+    },
+    {
+        "address": "2001::1:1/64",
+        "assigned_object_type": "dcim.interface",
+        "assigned_object_id": test100_gi2.id,
+        "status": "active",
+    },
     {
         "address": "172.16.180.11/24",
         "dns_name": "nexus.example.com",
@@ -409,7 +482,13 @@ created_route_targets = make_nautobot_calls(nb.ipam.route_targets, route_targets
 
 # Create Relationship
 relationships = [
-    {"name": "VLAN to Device", "slug": "vlan-to-device", "type": "one-to-one", "source_type": "ipam.vlan", "destination_type": "dcim.device"},
+    {
+        "name": "VLAN to Device",
+        "slug": "vlan-to-device",
+        "type": "one-to-one",
+        "source_type": "ipam.vlan",
+        "destination_type": "dcim.device",
+    },
 ]
 created_relationships = make_nautobot_calls(nb.extras.relationships, relationships)
 

--- a/tests/integration/targets/latest/tasks/location.yml
+++ b/tests/integration/targets/latest/tasks/location.yml
@@ -7,7 +7,8 @@
 - block:
   - set_fact:
       site: "{{ lookup('networktocode.nautobot.lookup', 'sites', api_endpoint=nautobot_url, token=nautobot_token, api_filter='slug=test-site') }}"
-      location_type: "{{ lookup('networktocode.nautobot.lookup', 'location_types', api_endpoint=nautobot_url, token=nautobot_token, api_filter='slug=my-location-type') }}"
+      parent_location_type: "{{ lookup('networktocode.nautobot.lookup', 'location_types', api_endpoint=nautobot_url, token=nautobot_token, api_filter='slug=my-parent-location-type') }}"
+      child_location_type: "{{ lookup('networktocode.nautobot.lookup', 'location_types', api_endpoint=nautobot_url, token=nautobot_token, api_filter='slug=my-child-location-type') }}"
 
   - name: "1 - Create location within Nautobot with only required information"
     networktocode.nautobot.location:
@@ -15,7 +16,7 @@
       token: "{{ nautobot_token }}"
       name: Test Location
       status: Active
-      location_type: "{{ location_type['key'] }}"
+      location_type: "{{ parent_location_type['key'] }}"
       site: "{{ site['key'] }}"
     register: test_create_min
 
@@ -28,7 +29,7 @@
         - test_create_min['location']['name'] == "Test Location"
         - test_create_min['location']['status'] == "active"
         - test_create_min['location']['site'] == site["key"]
-        - test_create_min['location']['location_type'] == location_type["key"]
+        - test_create_min['location']['location_type'] == parent_location_type["key"]
         - test_create_min['msg'] == "location Test Location created"
 
   - name: "2 - Duplicate"
@@ -37,7 +38,7 @@
       token: "{{ nautobot_token }}"
       name: Test Location
       status: Active
-      location_type: "{{ location_type['key'] }}"
+      location_type: "{{ parent_location_type['key'] }}"
       site: "{{ site['key'] }}"
     register: test_create_idem
 
@@ -54,7 +55,7 @@
       token: "{{ nautobot_token }}"
       name: Test Location
       status: Active
-      location_type: "{{ location_type['key'] }}"
+      location_type: "{{ parent_location_type['key'] }}"
       site: "{{ site['key'] }}"
       description: Test Location Description
     register: test_update
@@ -73,8 +74,7 @@
       name: Test Location 2
       status: Active
       description: Test Location 2 Description
-      location_type: "{{ location_type['key'] }}"
-      site: "{{ site['key'] }}"
+      location_type: "{{ child_location_type['key'] }}"
       parent: "{{ test_create_min['location']['id'] }}"
       state: present
     register: test_create_max
@@ -89,8 +89,7 @@
         - test_create_max['location']['status'] == "active"
         - test_create_max['msg'] == "location Test Location 2 created"
         - test_create_max['location']['description'] == "Test Location 2 Description"
-        - test_create_max['location']['site'] == site["key"]
-        - test_create_max['location']['location_type'] == location_type["key"]
+        - test_create_max['location']['location_type'] == child_location_type["key"]
         - test_create_max['location']['parent'] == test_create_min['location']['id']
 
   - name: "5 - Duplicate create with all parameters"
@@ -100,8 +99,7 @@
       name: Test Location 2
       status: Active
       description: Test Location 2 Description
-      location_type: "{{ location_type['key'] }}"
-      site: "{{ site['key'] }}"
+      location_type: "{{ child_location_type['key'] }}"
       parent: "{{ test_create_min['location']['id'] }}"
       state: present
     register: test_create_max_idem


### PR DESCRIPTION
Closes: #177 

I split the jobs out into a separate file for a couple reasons:
- This allows you to disable/enable the scheduled workflow independently (helpful for forked repositories)
- We can now look to prune down the number of tests that run for PRs to only the most common versions while still having a larger test base that can be enabled for the scheduled run.