### PR TITLE
Add support for module truststore

### DIFF
--- a/plugins/action/query_graphql.py
+++ b/plugins/action/query_graphql.py
@@ -19,6 +19,14 @@ else:
     PYNAUTOBOT_IMPORT_ERROR = None
 
 try:
+    import truststore
+    truststore.inject_into_ssl()
+except ImportError as imp_exc:
+    TRUSTSTORE_IMPORT_ERROR = imp_exc
+else:
+    TRUSTSTORE_IMPORT_ERROR = None
+
+try:
     import requests
 except ImportError as imp_exc:
     REQUESTS_IMPORT_ERROR = imp_exc


### PR DESCRIPTION
Verify certificates using native system certificate stores when module truststore is available.
This enables users to connect to systems with private/custom ROOT CA signed certificates, without having to disable certificate verification.

https://pypi.org/project/truststore/