### PR TITLE
Changes Location to look up by name/parent

### DIFF
--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -106,7 +106,7 @@ QUERY_TYPES = dict(
     group="name",
     installed_device="name",
     import_targets="name",
-    location="id",
+    location="name",
     manufacturer="name",
     master="name",
     nat_inside="address",
@@ -305,7 +305,7 @@ ALLOWED_QUERY_PARAMS = {
     "ipaddresses": set(["address", "namespace", "device", "interfaces", "vm_interfaces"]),
     "ip_address_to_interface": set(["ip_address", "interface", "vm_interface"]),
     "lag": set(["name"]),
-    "location": set(["name", "id"]),
+    "location": set(["name", "id", "parent"]),
     "location_type": set(["name"]),
     "manufacturer": set(["name"]),
     "master": set(["name"]),
@@ -783,8 +783,6 @@ class NautobotModule:
                 # Do not attempt to resolve if already ID/UUID is provided
                 if isinstance(v, int) or self.is_valid_uuid(v):
                     continue
-                elif k == "location":
-                    self._handle_errors(msg="Location needs a valid UUID")
                 # Special circumstances to set endpoint to search within
                 elif k == "termination_a":
                     endpoint = CONVERT_TO_ID[data.get("termination_a_type")]

--- a/plugins/modules/circuit_termination.py
+++ b/plugins/modules/circuit_termination.py
@@ -94,7 +94,9 @@ EXAMPLES = r"""
         token: thisIsMyToken
         circuit: Test Circuit
         term_side: A
-        location: "{{ location['key'] }}"
+        location:
+          name: My Location
+          parent: Parent Location
         port_speed: 10000
         state: present
 

--- a/plugins/modules/cluster.py
+++ b/plugins/modules/cluster.py
@@ -101,7 +101,9 @@ EXAMPLES = r"""
         name: Test Cluster
         cluster_type: qemu
         cluster_group: GROUP
-        location: "{{ location['key'] }}"
+        location:
+          name: My Location
+          parent: Parent Location
         state: present
 """
 

--- a/plugins/modules/device.py
+++ b/plugins/modules/device.py
@@ -72,7 +72,7 @@ options:
     description:
       - Required if I(state=present) and the device does not exist yet
     required: false
-    type: str
+    type: raw
     version_added: "3.0.0"
   rack:
     description:
@@ -180,11 +180,9 @@ EXAMPLES = r"""
         name: Test Device
         device_type: C9410R
         role: Core Switch
-        location: "{{ my_location['key'] }}"
+        location: My Location
         status: active
         state: present
-      vars:
-        my_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"My Location\"') }}"
 
     - name: Create device within Nautobot with empty string name to generate UUID
       networktocode.nautobot.device:
@@ -193,11 +191,11 @@ EXAMPLES = r"""
         name: ""
         device_type: C9410R
         role: Core Switch
-        location: "{{ my_location['key'] }}"
+        location:
+          name: My Location
+          parent: Parent Location
         status: active
         state: present
-      vars:
-        my_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"My Location\"') }}"
 
     - name: Delete device within nautobot
       networktocode.nautobot.device:
@@ -213,15 +211,15 @@ EXAMPLES = r"""
         name: Another Test Device
         device_type: C9410R
         role: Core Switch
-        location: "{{ my_location['key'] }}"
+        location:
+          name: My Location
+          parent: Parent Location
         status: active
         local_config_context_data:
           bgp: "65000"
         tags:
           - Schnozzberry
         state: present
-      vars:
-        my_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"My Location\"') }}"
 
     - name: Update the rack and position of an existing device
       networktocode.nautobot.device:
@@ -269,7 +267,7 @@ def main():
             platform=dict(required=False, type="raw"),
             serial=dict(required=False, type="str"),
             asset_tag=dict(required=False, type="str"),
-            location=dict(required=False, type="str"),
+            location=dict(required=False, type="raw"),
             rack=dict(required=False, type="raw"),
             position=dict(required=False, type="int"),
             face=dict(

--- a/plugins/modules/power_panel.py
+++ b/plugins/modules/power_panel.py
@@ -55,7 +55,7 @@ EXAMPLES = r"""
         url: http://nautobot.local
         token: thisIsMyToken
         name: Test Power Panel
-        location: Test location
+        location: My Location
         state: present
 
     - name: Update power panel with other fields
@@ -63,7 +63,9 @@ EXAMPLES = r"""
         url: http://nautobot.local
         token: thisIsMyToken
         name: Test Power Panel
-        location: Test location
+        location:
+          name: My Location
+          parent: Parent Location
         rack_group: Test Rack Group
         state: present
 
@@ -72,7 +74,9 @@ EXAMPLES = r"""
         url: http://nautobot.local
         token: thisIsMyToken
         name: Test Power Panel
-        location: Test location
+        location:
+          name: My Location
+          parent: Parent Location
         state: absent
 """
 

--- a/plugins/modules/prefix.py
+++ b/plugins/modules/prefix.py
@@ -145,11 +145,11 @@ EXAMPLES = r"""
         token: thisIsMyToken
         family: 4
         prefix: 10.156.32.0/19
-        location: Test Location
+        location: My Location
         tenant: Test Tenant
         vlan:
           name: Test VLAN
-          location: Test Location
+          location: My Location
           tenant: Test Tenant
           vlan_group: Test Vlan Group
         status: Reserved
@@ -191,7 +191,9 @@ EXAMPLES = r"""
         token: thisIsMyToken
         parent: 10.157.0.0/19
         prefix_length: 24
-        location: Test Location
+        location:
+          name: My Location
+          parent: Parent Location
         state: present
         first_available: yes
 """

--- a/plugins/modules/rack.py
+++ b/plugins/modules/rack.py
@@ -150,7 +150,9 @@ EXAMPLES = r"""
         url: http://nautobot.local
         token: thisIsMyToken
         name: Test rack
-        location: Test Location
+        location:
+          name: My Location
+          parent: Parent Location
         status: active
         state: present
 

--- a/plugins/modules/rack_group.py
+++ b/plugins/modules/rack_group.py
@@ -60,7 +60,7 @@ EXAMPLES = r"""
         url: http://nautobot.local
         token: thisIsMyToken
         name: Test rack group
-        location: Test Location
+        location: My Location
         state: present
 
     - name: Delete rack group within nautobot
@@ -68,7 +68,9 @@ EXAMPLES = r"""
         url: http://nautobot.local
         token: thisIsMyToken
         name: Test Rack group
-        location: Test Location
+        location:
+          name: My Location
+          parent: Parent Location
         state: absent
 """
 

--- a/plugins/modules/vlan.py
+++ b/plugins/modules/vlan.py
@@ -106,7 +106,9 @@ EXAMPLES = r"""
         token: thisIsMyToken
         name: Test VLAN
         vid: 400
-        location: Test Site
+        location:
+          name: My Location
+          parent: Parent Location
         group: Test VLAN Group
         tenant: Test Tenant
         status: Deprecated

--- a/plugins/modules/vlan_group.py
+++ b/plugins/modules/vlan_group.py
@@ -54,7 +54,9 @@ EXAMPLES = r"""
         url: http://nautobot.local
         token: thisIsMyToken
         name: Test vlan group
-        location: Test Location
+        location:
+          name: My Location
+          parent: Parent Location
         state: present
 
     - name: Delete vlan group within nautobot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,3 +69,10 @@ exclude = '''
                      # the root of the project
 )
 '''
+
+[tool.pylint.messages_control]
+# Line length is enforced by Black, so pylint doesn't need to check it.
+# Pylint and Black disagree about how to format multi-line arrays; Black wins.
+disable = """,
+    line-too-long
+    """

--- a/tests/integration/nautobot-populate.py
+++ b/tests/integration/nautobot-populate.py
@@ -120,16 +120,20 @@ child_location_type = nb.dcim.location_types.get(name="My Child Location Type")
 # Create locations
 parent_location_attrs = [
     {"name": "Parent Test Location", "location_type": parent_location_type.id, "tenant": test_tenant.id, "status": {"name": "Active"}},
+    {"name": "Parent Test Location 2", "location_type": parent_location_type.id, "tenant": test_tenant.id, "status": {"name": "Active"}},
 ]
 make_nautobot_calls(nb.dcim.locations, parent_location_attrs)
 
 # Location variables to be used later on
 location_parent = nb.dcim.locations.get(name="Parent Test Location")
+location_parent2 = nb.dcim.locations.get(name="Parent Test Location 2")
 child_location_attrs = [
     {"name": "Child Test Location", "location_type": child_location_type.id, "parent": location_parent.id, "status": {"name": "Active"}},
+    # Creating an intentionally duplicate location name with different parent to test looking up by parent
+    {"name": "Child Test Location", "location_type": child_location_type.id, "parent": location_parent2.id, "status": {"name": "Active"}},
 ]
 make_nautobot_calls(nb.dcim.locations, child_location_attrs)
-location_child = nb.dcim.locations.get(name="Child Test Location")
+location_child = nb.dcim.locations.get(name="Child Test Location", parent="Parent Test Location")
 
 child_child_location_attrs = [
     {"name": "Child-Child Test Location", "location_type": child_location_type.id, "parent": location_child.id, "status": {"name": "Active"}},

--- a/tests/integration/targets/inventory/files/test-inventory-plurals-flatten.json
+++ b/tests/integration/targets/inventory/files/test-inventory-plurals-flatten.json
@@ -311,6 +311,7 @@
             "nexus_parent",
             "parent_rack_group",
             "parent_test_location",
+            "parent_test_location_2",
             "sub_test_rack",
             "test_cluster",
             "test_cluster_2",
@@ -408,6 +409,11 @@
             "test101-vm",
             "test102-vm",
             "test103-vm"
+        ]
+    },
+    "parent_test_location_2": {
+        "children": [
+            "child_test_location"
         ]
     },
     "sub_test_rack": {

--- a/tests/integration/targets/inventory/files/test-inventory-plurals.json
+++ b/tests/integration/targets/inventory/files/test-inventory-plurals.json
@@ -2114,6 +2114,7 @@
             "device_types_nexus_parent",
             "is_virtual",
             "location_parent_test_location",
+            "location_parent_test_location_2",
             "locations_child_child_test_location",
             "locations_child_test_location",
             "locations_parent_test_location",
@@ -2197,6 +2198,11 @@
         ]
     },
     "location_parent_test_location": {
+        "children": [
+            "location_child_test_location"
+        ]
+    },
+    "location_parent_test_location_2": {
         "children": [
             "location_child_test_location"
         ]

--- a/tests/integration/targets/latest/tasks/circuit_termination.yml
+++ b/tests/integration/targets/latest/tasks/circuit_termination.yml
@@ -5,7 +5,7 @@
 ##
 ##
 - set_fact:
-    test_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\"') }}"
+    test_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\" parent=\"Parent Test Location\"') }}"
     circuit: '{{ lookup(''networktocode.nautobot.lookup'', ''circuits'', api_endpoint=nautobot_url, token=nautobot_token, api_filter=''cid="Test Circuit"'') }}'
     circuit2: '{{ lookup(''networktocode.nautobot.lookup'', ''circuits'', api_endpoint=nautobot_url, token=nautobot_token, api_filter=''cid="Test Circuit Two"'') }}'
     provider_network: '{{ lookup(''networktocode.nautobot.lookup'', ''provider-networks'', api_endpoint=nautobot_url, token=nautobot_token, api_filter=''name="Test Provider Network"'') }}'
@@ -16,7 +16,9 @@
     token: "{{ nautobot_token }}"
     circuit: Test Circuit
     term_side: A
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     port_speed: 10000
     state: present
   register: test_one
@@ -89,7 +91,9 @@
     token: "{{ nautobot_token }}"
     circuit: Test Circuit
     term_side: Z
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     port_speed: 10000
     state: present
   register: test_four

--- a/tests/integration/targets/latest/tasks/cluster.yml
+++ b/tests/integration/targets/latest/tasks/cluster.yml
@@ -7,7 +7,7 @@
 - set_fact:
     test_cluster_type: "{{ lookup('networktocode.nautobot.lookup', 'cluster-types', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Test Cluster Type\"') }}"
     test_cluster_group: "{{ lookup('networktocode.nautobot.lookup', 'cluster-groups', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Test Cluster Group\"') }}"
-    test_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\"') }}"
+    test_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\" parent=\"Parent Test Location\"') }}"
     tenant: "{{ lookup('networktocode.nautobot.lookup', 'tenants', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Test Tenant\"') }}"
     tag_schnozzberry: "{{ lookup('networktocode.nautobot.lookup', 'tags', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=Schnozzberry') }}"
 
@@ -54,7 +54,9 @@
     name: "Test Cluster One"
     cluster_type: "Test Cluster Type"
     cluster_group: "Test Cluster Group"
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     comments: "Updated cluster"
     tenant: "Test Tenant"
     tags:

--- a/tests/integration/targets/latest/tasks/device.yml
+++ b/tests/integration/targets/latest/tasks/device.yml
@@ -6,7 +6,7 @@
 ##
 - set_fact:
     parent_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Parent Test Location\"') }}"
-    child_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\"') }}"
+    child_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\" parent=\"Parent Test Location\"') }}"
     device_type: "{{ lookup('networktocode.nautobot.lookup', 'device-types', api_endpoint=nautobot_url, token=nautobot_token, api_filter='model=\"Cisco Test\"') }}"
     role: "{{ lookup('networktocode.nautobot.lookup', 'roles', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Core Switch\"') }}"
     vc1: "{{ lookup('networktocode.nautobot.lookup', 'virtual-chassis', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=VC1') }}"
@@ -22,7 +22,7 @@
     device_type:
       id: "{{ device_type['key'] }}"
     role: "Core Switch"
-    location: "{{ parent_location['key'] }}"
+    location: Parent Test Location
     status: "Staged"
     state: present
   register: test_one
@@ -41,26 +41,6 @@
       - test_one['device']['name'] == "R1"
       - test_one['msg'] == "device R1 created"
 
-- name: "1.1 - Device with location not as UUID"
-  networktocode.nautobot.device:
-    url: "{{ nautobot_url }}"
-    token: "{{ nautobot_token }}"
-    name: "R11"
-    device_type:
-      id: "{{ device_type['key'] }}"
-    role: "Core Switch"
-    location: Parent Test Location
-    status: "Staged"
-    state: present
-  register: test_one_one
-  ignore_errors: true
-
-- name: "1.1 - ASSERT"
-  assert:
-    that:
-      - test_one_one is failed
-      - test_one_one['msg'] == "Location needs a valid UUID"
-
 - name: "2 - Duplicate device"
   networktocode.nautobot.device:
     url: "{{ nautobot_url }}"
@@ -68,7 +48,7 @@
     name: "R1"
     device_type: "Cisco Test"
     role: "Core Switch"
-    location: "{{ parent_location['key'] }}"
+    location: Parent Test Location
     status: "Staged"
     state: present
   register: test_two
@@ -187,7 +167,9 @@
     name: "TestR1"
     device_type: "1841"
     role: "Core Switch"
-    location: "{{ child_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     rack: "Main Test Rack"
     status: "Active"
     position: 35
@@ -293,7 +275,7 @@
     device_type:
       id: "{{ device_type['key'] }}"
     role: "Core Switch"
-    location: "{{ parent_location['key'] }}"
+    location: "Parent Test Location"
     status: "Staged"
     state: present
   register: test_eight

--- a/tests/integration/targets/latest/tasks/device_interface.yml
+++ b/tests/integration/targets/latest/tasks/device_interface.yml
@@ -6,7 +6,6 @@
 ##
 - set_fact:
     test100: "{{ lookup('networktocode.nautobot.lookup', 'devices', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=test100') }}"
-    child_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\"') }}"
 
 - name: "1 - Interface with required information"
   networktocode.nautobot.device_interface:
@@ -143,12 +142,12 @@
     type: 1000Base-T (1GE)
     untagged_vlan:
       name: Wireless
-      location: "{{ child_location['key'] }}"
+      location: "Child Test Location"
     tagged_vlans:
       - name: Data
-        location: "{{ child_location['key'] }}"
+        location: "Child Test Location"
       - name: VoIP
-        location: "{{ child_location['key'] }}"
+        location: "Child Test Location"
     mtu: 1600
     mgmt_only: true
     mode: Tagged

--- a/tests/integration/targets/latest/tasks/lookup.yml
+++ b/tests/integration/targets/latest/tasks/lookup.yml
@@ -4,9 +4,9 @@
 ### PYNAUTOBOT_LOOKUP
 ##
 ##
-- name: "PYNAUTOBOT_LOOKUP 1: Lookup returns exactly three locations"
+- name: "PYNAUTOBOT_LOOKUP 1: Lookup returns exactly five locations"
   assert:
-    that: "{{ query_result|count }} == 3"
+    that: "{{ query_result|count }} == 5"
   vars:
     query_result: "{{ query('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token) }}"
 
@@ -39,7 +39,9 @@
     name: "L1"
     device_type: "Cisco Test"
     role: "Core Switch"
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     status: "Staged"
     tags:
       - "Nolookup"
@@ -52,7 +54,7 @@
     name: "L2"
     device_type: "Cisco Test"
     role: "Core Switch"
-    location: "{{ child_test_location['key'] }}"
+    location: "Child-Child Test Location"
     status: "Staged"
     tags:
       - "Lookup"

--- a/tests/integration/targets/latest/tasks/power_outlet.yml
+++ b/tests/integration/targets/latest/tasks/power_outlet.yml
@@ -7,9 +7,6 @@
 ### PYNAUTOBOT_POWER_OUTLET
 ##
 ##
-- set_fact:
-    test_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\"') }}"
-
 - name: "POWER_PORT 0: Create device for testing power ports"
   networktocode.nautobot.device:
     url: "{{ nautobot_url }}"
@@ -17,7 +14,9 @@
     name: Device Power Outlet
     device_type: Cisco Test
     role: Core Switch
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     status: "Active"
     state: present
 

--- a/tests/integration/targets/latest/tasks/power_panel.yml
+++ b/tests/integration/targets/latest/tasks/power_panel.yml
@@ -8,7 +8,7 @@
 ##
 ##
 - set_fact:
-    test_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\"') }}"
+    test_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\" parent=\"Parent Test Location\"') }}"
     rack_group: "{{ lookup('networktocode.nautobot.lookup', 'rack-groups', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Parent Rack Group\"') }}"
 
 - name: "POWER_PANEL 1: Necessary info creation"
@@ -16,7 +16,9 @@
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
     name: Power Panel
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     state: present
   register: test_one
 
@@ -35,7 +37,9 @@
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
     name: Power Panel
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     state: present
   register: test_two
 
@@ -52,7 +56,9 @@
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
     name: Power Panel
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     rack_group: Parent Rack Group
     state: present
   register: test_three
@@ -72,7 +78,9 @@
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
     name: Power Panel 2
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     state: present
   register: test_four
 
@@ -91,7 +99,9 @@
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
     name: Power Panel 2
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     state: absent
   register: test_five
 

--- a/tests/integration/targets/latest/tasks/power_port.yml
+++ b/tests/integration/targets/latest/tasks/power_port.yml
@@ -7,9 +7,6 @@
 ### PYNAUTOBOT_POWER_PORT
 ##
 ##
-- set_fact:
-    test_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\"') }}"
-
 - name: "POWER_PORT 0: Create device for testing power ports"
   networktocode.nautobot.device:
     url: "{{ nautobot_url }}"
@@ -18,7 +15,9 @@
     device_type: Cisco Test
     role: Core Switch
     status: "Active"
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     state: present
 
 - set_fact:

--- a/tests/integration/targets/latest/tasks/prefix.yml
+++ b/tests/integration/targets/latest/tasks/prefix.yml
@@ -5,7 +5,7 @@
 ##
 ##
 - set_fact:
-    test_child_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\"') }}"
+    test_child_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\" parent=\"Parent Test Location\"') }}"
     tenant: "{{ lookup('networktocode.nautobot.lookup', 'tenants', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Test Tenant\"') }}"
     tag_schnozzberry: "{{ lookup('networktocode.nautobot.lookup', 'tags', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=Schnozzberry') }}"
     vlan_group: "{{ lookup('networktocode.nautobot.lookup', 'vlan-groups', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Test Vlan Group\"') }}"
@@ -54,7 +54,9 @@
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
     prefix: 10.156.0.0/19
-    location: "{{ test_child_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     status: Reserved
     description: "This prefix has been updated"
     state: present
@@ -95,11 +97,13 @@
     token: "{{ nautobot_token }}"
     ip_version: 4
     prefix: 10.156.32.0/19
-    location: "{{ test_child_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     tenant: Test Tenant
     vlan:
       name: Test VLAN
-      location: "{{ test_child_location['key'] }}"
+      location: "Child Test Location"
       tenant: Test Tenant
       vlan_group: Test Vlan Group
     status: Reserved
@@ -192,7 +196,9 @@
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
     prefix: 10.157.0.0/19
-    location: "{{ test_child_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     status: "Active"
     state: present
   register: test_nine
@@ -213,7 +219,9 @@
     token: "{{ nautobot_token }}"
     parent: 10.157.0.0/19
     prefix_length: 24
-    location: "{{ test_child_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     status: "Active"
     state: present
     first_available: yes
@@ -254,7 +262,9 @@
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
     prefix: 10.157.0.0/19
-    location: "{{ test_child_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     namespace: Private
     status: "Active"
     state: present
@@ -277,7 +287,9 @@
     token: "{{ nautobot_token }}"
     parent: 10.157.0.0/19
     prefix_length: 24
-    location: "{{ test_child_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     namespace: Private
     status: "Active"
     state: present

--- a/tests/integration/targets/latest/tasks/rack.yml
+++ b/tests/integration/targets/latest/tasks/rack.yml
@@ -5,7 +5,7 @@
 ##
 ##
 - set_fact:
-    test_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\"') }}"
+    test_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\" parent=\"Parent Test Location\"') }}"
     tenant: "{{ lookup('networktocode.nautobot.lookup', 'tenants', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Test Tenant\"') }}"
     tag_schnozzberry: "{{ lookup('networktocode.nautobot.lookup', 'tags', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=Schnozzberry') }}"
     rack_role: "{{ lookup('networktocode.nautobot.lookup', 'roles', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Test Rack Role\"') }}"
@@ -19,7 +19,9 @@
     name: "Test rack one"
     rack_group: "Parent Rack Group"
     status: "Available"
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
   register: test_one
 
 - name: "1 - ASSERT"
@@ -55,7 +57,9 @@
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
     name: Test rack - Child Test Location
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     rack_group: "Parent Rack Group"
     status: "Available"
     state: present
@@ -77,7 +81,9 @@
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
     name: Test rack one
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     rack_group: "Parent Rack Group"
     status: "Available"
     state: present
@@ -97,7 +103,9 @@
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
     name: Test rack one
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     role: "Test Rack Role"
     rack_group: "Parent Rack Group"
     facility_id: "EQUI10291"
@@ -158,7 +166,9 @@
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
     name: Test rack one
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     role: "Test Rack Role"
     rack_group: "Parent Rack Group"
     facility_id: "EQUI10291"
@@ -205,7 +215,9 @@
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
     name: Test rack two
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     serial: "FXS10001"
     asset_tag: "1234"
     status: Available

--- a/tests/integration/targets/latest/tasks/rack_group.yml
+++ b/tests/integration/targets/latest/tasks/rack_group.yml
@@ -5,14 +5,16 @@
 ##
 ##
 - set_fact:
-    test_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\"') }}"
+    test_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\" parent=\"Parent Test Location\"') }}"
 
 - name: "RACK_GROUP 1: Necessary info creation"
   networktocode.nautobot.rack_group:
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
     name: Rack Group
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     state: present
   register: test_one
 
@@ -31,7 +33,9 @@
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
     name: Rack Group
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     state: present
   register: test_two
 

--- a/tests/integration/targets/latest/tasks/service.yml
+++ b/tests/integration/targets/latest/tasks/service.yml
@@ -6,7 +6,6 @@
 ##
 - set_fact:
     tag_schnozzberry: "{{ lookup('networktocode.nautobot.lookup', 'tags', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=Schnozzberry') }}"
-    test_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\"') }}"
 
 - name: "1 - Device with required information needs to add new service"
   networktocode.nautobot.device:
@@ -15,7 +14,9 @@
     name: "FOR_SERVICE"
     device_type: "Cisco Test"
     role: "Core Switch"
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     status: "Staged"
     state: present
 

--- a/tests/integration/targets/latest/tasks/virtual_chassis.yml
+++ b/tests/integration/targets/latest/tasks/virtual_chassis.yml
@@ -7,9 +7,6 @@
 ### PYNAUTOBOT_VIRTUAL_CHASSIS
 ##
 ##
-- set_fact:
-    test_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\"') }}"
-
 - name: "VIRTUAL_CHASSIS 0: Create device for testing virtual chassis"
   networktocode.nautobot.device:
     url: "{{ nautobot_url }}"
@@ -17,7 +14,9 @@
     name: Device Virtual Chassis Tests
     device_type: Cisco Test
     role: Core Switch
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     vc_position: 1
     vc_priority: 1
     status: "Active"
@@ -89,7 +88,9 @@
     name: Device Virtual Chassis Tests 2
     device_type: Cisco Test
     role: Core Switch
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     vc_position: 1
     vc_priority: 15
     status: "Active"

--- a/tests/integration/targets/latest/tasks/vlan.yml
+++ b/tests/integration/targets/latest/tasks/vlan.yml
@@ -5,7 +5,7 @@
 ##
 ##
 - set_fact:
-    test_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\"') }}"
+    test_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\" parent=\"Parent Test Location\"') }}"
     tenant: "{{ lookup('networktocode.nautobot.lookup', 'tenants', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Test Tenant\"') }}"
     tag_schnozzberry: "{{ lookup('networktocode.nautobot.lookup', 'tags', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=Schnozzberry') }}"
     vlan_group: "{{ lookup('networktocode.nautobot.lookup', 'vlan-groups', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Test Vlan Group\"') }}"
@@ -56,7 +56,9 @@
     token: "{{ nautobot_token }}"
     name: Test VLAN 500
     vid: 500
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     tenant: Test Tenant
     vlan_group: "Test Vlan Group"
     status: "Active"
@@ -87,7 +89,9 @@
     status: Reserved
     role: Network of care
     description: Updated description
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     tags:
       - "Schnozzberry"
     state: present
@@ -122,7 +126,9 @@
     status: Reserved
     role: Network of care
     description: Updated description
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     tags:
       - "Schnozzberry"
     state: present
@@ -139,7 +145,9 @@
     token: "{{ nautobot_token }}"
     name: Test VLAN 500
     vid: 500
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     tenant: Test Tenant
     status: "Active"
     vlan_group: "Test Vlan Group 2"
@@ -181,7 +189,9 @@
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
     name: "Test VLAN 500"
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     vlan_group: "Test Vlan Group"
     state: absent
   register: test_six

--- a/tests/integration/targets/latest/tasks/vlan_group.yml
+++ b/tests/integration/targets/latest/tasks/vlan_group.yml
@@ -5,7 +5,7 @@
 ##
 ##
 - set_fact:
-    test_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\"') }}"
+    test_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\" parent=\"Parent Test Location\"') }}"
     test_location2: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child-Child Test Location\"') }}"
 
 - name: "VLAN_GROUP 1: Necessary info creation"
@@ -13,7 +13,9 @@
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
     name: "VLAN Group One"
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     state: present
   register: test_one
 
@@ -32,7 +34,9 @@
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
     name: "VLAN Group One"
-    location: "{{ test_location['key'] }}"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
     state: present
   register: test_two
 
@@ -49,7 +53,7 @@
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
     name: "VLAN Group One"
-    location: "{{ test_location2['key'] }}"
+    location: "Child-Child Test Location"
     state: present
   register: test_three
   ignore_errors: true

--- a/tests/integration/targets/latest/tasks/vm_interface.yml
+++ b/tests/integration/targets/latest/tasks/vm_interface.yml
@@ -8,7 +8,6 @@
     vm100: "{{ lookup('networktocode.nautobot.lookup', 'virtual-machines', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=test100-vm') }}"
     tag_schnozzberry: "{{ lookup('networktocode.nautobot.lookup', 'tags', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=Schnozzberry') }}"
     wireless: "{{ lookup('networktocode.nautobot.lookup', 'vlans', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=Wireless') }}"
-    test_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\"') }}"
 
 - name: "PYNAUTOBOT_VM_INTERFACE 1: Necessary info creation"
   networktocode.nautobot.vm_interface:
@@ -62,12 +61,12 @@
     mode: Tagged
     untagged_vlan:
       name: Wireless
-      location: "{{ test_location['key'] }}"
+      location: "Child Test Location"
     tagged_vlans:
       - name: Data
-        location: "{{ test_location['key'] }}"
+        location: "Child Test Location"
       - name: VoIP
-        location: "{{ test_location['key'] }}"
+        location: "Child Test Location"
     tags:
       - "Schnozzberry"
     state: present
@@ -128,12 +127,12 @@
     mode: Tagged
     untagged_vlan:
       name: Wireless
-      location: "{{ test_location['key'] }}"
+      location: "Child Test Location"
     tagged_vlans:
       - name: Data
-        location: "{{ test_location['key'] }}"
+        location: "Child Test Location"
       - name: VoIP
-        location: "{{ test_location['key'] }}"
+        location: "Child Test Location"
     tags:
       - "Schnozzberry"
     state: present

--- a/tests/integration/targets/regression-latest/tasks/main.yml
+++ b/tests/integration/targets/regression-latest/tasks/main.yml
@@ -4,9 +4,6 @@
 ### TEST PYNAUTOBOT CONNECTION FAILURE
 ##
 ##
-- set_fact:
-    location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\"') }}"
-
 - name: "TEST PYNAUTOBOT CONNECTION FAILURE"
   connection: local
   block:
@@ -17,7 +14,9 @@
         name: "R1"
         device_type: "Cisco Test"
         role: "Core Switch"
-        location: "{{ location['key'] }}"
+        location:
+          name: "Child Test Location"
+          parent: "Parent Test Location"
         status: "Staged"
         state: present
       register: test_one
@@ -55,7 +54,9 @@
         name: "issue-242"
         device_type: "Cisco Test"
         role: "Core Switch"
-        location: "{{ location['key'] }}"
+        location:
+          name: "Child Test Location"
+          parent: "Parent Test Location"
         status: "Staged"
         tags:
           - name: First
@@ -68,7 +69,9 @@
         name: "issue-242"
         device_type: "Cisco Test"
         role: "Core Switch"
-        location: "{{ location['key'] }}"
+        location:
+          name: "Child Test Location"
+          parent: "Parent Test Location"
         status: "Staged"
         tags:
           - name: Second
@@ -88,7 +91,9 @@
         name: "issue-242"
         device_type: "Cisco Test"
         role: "Core Switch"
-        location: "{{ location['key'] }}"
+        location:
+          name: "Child Test Location"
+          parent: "Parent Test Location"
         status: "Staged"
         asset_tag: "1234"
         tags:
@@ -148,7 +153,9 @@
         name: "issue-242"
         device_type: "Cisco Test"
         role: "Core Switch"
-        location: "{{ location['key'] }}"
+        location:
+          name: "Child Test Location"
+          parent: "Parent Test Location"
         status: "Staged"
         asset_tag: "Null"
         tags:


### PR DESCRIPTION
This changes all `location` options to accept either a UUID, a name as a `str` or a dict of name and parent.

Closes: #286 