### PR TITLE
Fixes tests for latest ansible versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,12 +52,12 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.10"
+          - "3.9"
         nautobot-version:
           - "2.0"
         ansible-version:
+          - "2.14"
           - "2.15"
-          - "2.16"
     with:
       python-version: "${{ matrix.python-version }}"
       nautobot-version: "${{ matrix.nautobot-version }}"
@@ -79,12 +79,6 @@ jobs:
         ansible-version:
           - "2.14"
           - "2.15"
-          - "2.16"
-        exclude:
-          # Ansible 2.16 dropped support for Python 3.9
-          - python-version: "3.9"
-            nautobot-version: "2.0"
-            ansible-version: "2.16"
     with:
       python-version: "${{ matrix.python-version }}"
       nautobot-version: "${{ matrix.nautobot-version }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,8 +56,8 @@ jobs:
         nautobot-version:
           - "2.0"
         ansible-version:
-          - "2.14"
           - "2.15"
+          - "2.16"
     with:
       python-version: "${{ matrix.python-version }}"
       nautobot-version: "${{ matrix.nautobot-version }}"
@@ -79,6 +79,7 @@ jobs:
         ansible-version:
           - "2.14"
           - "2.15"
+          - "2.16"
     with:
       python-version: "${{ matrix.python-version }}"
       nautobot-version: "${{ matrix.nautobot-version }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.9"
+          - "3.10"
         nautobot-version:
           - "2.0"
         ansible-version:
@@ -80,6 +80,11 @@ jobs:
           - "2.14"
           - "2.15"
           - "2.16"
+        exclude:
+          # Ansible 2.16 dropped support for Python 3.9
+          - python-version: "3.9"
+            nautobot-version: "2.0"
+            ansible-version: "2.16"
     with:
       python-version: "${{ matrix.python-version }}"
       nautobot-version: "${{ matrix.nautobot-version }}"

--- a/poetry.lock
+++ b/poetry.lock
@@ -150,14 +150,14 @@ files = [
 
 [[package]]
 name = "ansible-core"
-version = "2.15.5"
+version = "2.15.7"
 description = "Radically simple IT automation"
 category = "main"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "ansible-core-2.15.5.tar.gz", hash = "sha256:8cc539cb8d4349af3ffd901c70722f7a7a203ae6427ddac95ffdf546a6e41602"},
-    {file = "ansible_core-2.15.5-py3-none-any.whl", hash = "sha256:3efa234de5fce79ec98853f3369535b27cacd7ce498495b996030cd15c373735"},
+    {file = "ansible-core-2.15.7.tar.gz", hash = "sha256:bc51d011bdb67538d1ee043e0f8072b3a849b78897caf15b6f294160c5c7c6ba"},
+    {file = "ansible_core-2.15.7-py3-none-any.whl", hash = "sha256:8a7988b8fbd1f4bb5799becae120b828de6248ba9056d83f427235533d655e2b"},
 ]
 
 [package.dependencies]
@@ -1179,16 +1179,6 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -1702,7 +1692,6 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
-    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -1710,15 +1699,8 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
-    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
-    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -1735,7 +1717,6 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
-    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -1743,7 +1724,6 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},

--- a/tests/integration/targets/latest/tasks/lookup.yml
+++ b/tests/integration/targets/latest/tasks/lookup.yml
@@ -6,25 +6,25 @@
 ##
 - name: "PYNAUTOBOT_LOOKUP 1: Lookup returns exactly five locations"
   assert:
-    that: "{{ query_result|count }} == 5"
+    that: "query_result | count == 5"
   vars:
     query_result: "{{ query('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token) }}"
 
 - name: "PYNAUTOBOT_LOOKUP 2: Query doesn't return Wibble (sanity check json_query)"
   assert:
-    that: "{{ query_result|json_query('[?value.display==`Wibble`]')|count }} == 0"
+    that: "query_result | json_query('[?value.display==`Wibble`]') | count == 0"
   vars:
     query_result: "{{ query('networktocode.nautobot.lookup', 'devices', api_endpoint=nautobot_url, token=nautobot_token) }}"
 
 - name: "PYNAUTOBOT_LOOKUP 3: Device query returns exactly one TestDeviceR1"
   assert:
-    that: "{{ query_result|json_query('[?value.display==`TestDeviceR1`]')|count }} == 1"
+    that: "query_result | json_query('[?value.display==`TestDeviceR1`]') | count == 1"
   vars:
     query_result: "{{ query('networktocode.nautobot.lookup', 'devices', api_endpoint=nautobot_url, token=nautobot_token) }}"
 
 - name: "PYNAUTOBOT_LOOKUP 4: VLAN ID 400 can be queried and is named 'Test VLAN'"
   assert:
-    that: "{{ (query_result|json_query('[?value.vid==`400`].value.name'))[0] == 'Test VLAN' }}"
+    that: "query_result | json_query('[?value.vid==`400`].value.name') | first == 'Test VLAN'"
   vars:
     query_result: "{{ query('networktocode.nautobot.lookup', 'vlans', api_endpoint=nautobot_url, token=nautobot_token) }}"
 
@@ -62,20 +62,20 @@
 
 - name: "PYNAUTOBOT_LOOKUP 7: Device query returns exactly the L2 device"
   assert:
-    that: "{{ query_result|json_query('[?value.display==`L2`]')|count }} == 1"
+    that: "query_result | json_query('[?value.display==`L2`]') | count == 1"
   vars:
     query_result: "{{ query('networktocode.nautobot.lookup', 'devices', api_filter='role=\"Core Switch\" tags=Lookup', api_endpoint=nautobot_url, token=nautobot_token) }}"
 
 - name: "PYNAUTOBOT_LOOKUP 8: Device query specifying raw data returns payload without key/value dict"
   assert:
-    that: "{{ query_result|json_query('[?display==`L2`]')|count }} == 1"
+    that: "query_result | json_query('[?display==`L2`]') | count == 1"
   vars:
     query_result: "{{ query('networktocode.nautobot.lookup', 'devices', api_filter='role=\"Core Switch\" tags=Lookup', api_endpoint=nautobot_url, token=nautobot_token, raw_data=True) }}"
 
 - name: "PYNAUTOBOT_LOOKUP 9: Device query specifying multiple locations, Make sure L1 and L2 are in the results"
   assert:
     that:
-      - "'L1' in {{ query_result |json_query('[*].display') }}"
-      - "'L2' in {{ query_result |json_query('[*].display') }}"
+      - "'L1' in query_result | json_query('[*].display')"
+      - "'L2' in query_result | json_query('[*].display')"
   vars:
     query_result: "{{ query('networktocode.nautobot.lookup', 'devices', api_filter='role=\"Core Switch\" location=\"Child Test Location\" location=\"Child-Child Test Location\"', api_endpoint=nautobot_url, token=nautobot_token, raw_data=True) }}"

--- a/tests/integration/targets/latest/tasks/relationship_association.yml
+++ b/tests/integration/targets/latest/tasks/relationship_association.yml
@@ -33,7 +33,7 @@
       - test_one['relationship_associations']['source_id'] == vlan['key']
       - test_one['relationship_associations']['destination_type'] == relationship['value']['destination_type']
       - test_one['relationship_associations']['destination_id'] == device['key']
-      - test_one['msg'] == "relationship_associations {{ relationship['value']['source_type'] }} -> {{ relationship['value']['destination_type'] }} created"
+      - "'created' in test_one['msg']"
 
 - name: "RELATIONSHIP ASSOCIATION 2: Test duplication association (Idempotency)"
   networktocode.nautobot.relationship_association:
@@ -52,7 +52,7 @@
     that:
       - test_two is not changed
       - test_two['relationship_associations']['relationship'] == relationship['key']
-      - test_two['msg'] == "relationship_associations {{ relationship['value']['source_type'] }} -> {{ relationship['value']['destination_type'] }} already exists"
+      - "'already exists' in test_two['msg']"
 
 - name: "RELATIONSHIP ASSOCIATION 3: Test absent state"
   networktocode.nautobot.relationship_association:
@@ -77,7 +77,7 @@
       - test_three['relationship_associations']['source_id'] == vlan['key']
       - test_three['relationship_associations']['destination_type'] == relationship['value']['destination_type']
       - test_three['relationship_associations']['destination_id'] == device['key']
-      - test_three['msg'] == "relationship_associations {{ relationship['value']['source_type'] }} -> {{ relationship['value']['destination_type'] }} deleted"
+      - "'deleted' in test_three['msg']"
 
 - name: "RELATIONSHIP ASSOCIATION 4: Test absent state (Idempotent)"
   networktocode.nautobot.relationship_association:
@@ -95,4 +95,4 @@
   assert:
     that:
       - test_four is not changed
-      - test_four['msg'] == "relationship_associations {{ relationship['value']['source_type'] }} -> {{ relationship['value']['destination_type'] }} already absent"
+      - "'already absent' in test_four['msg']"


### PR DESCRIPTION
The following minimum versions are incompatible with jinja templating inside assertions to combat CVE-2023-5764:
- 2.14.12
- 2.15.7
- 2.16.1