### PR TITLE
Remove status attribute requirement when state is present

### DIFF
--- a/plugins/modules/cable.py
+++ b/plugins/modules/cable.py
@@ -231,11 +231,7 @@ def main():
         )
     )
 
-    required_if = [
-        ("state", "absent", ["termination_a_type", "termination_a", "termination_b_type", "termination_b"]),
-    ]
-
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     cable = NautobotDcimModule(module, NB_CABLES)
     cable.run()

--- a/plugins/modules/cable.py
+++ b/plugins/modules/cable.py
@@ -235,7 +235,7 @@ def main():
         (
             "state",
             "present",
-            ["termination_a_type", "termination_a", "termination_b_type", "termination_b", "status"],
+            ["termination_a_type", "termination_a", "termination_b_type", "termination_b"],
         ),
         ("state", "absent", ["termination_a_type", "termination_a", "termination_b_type", "termination_b"]),
     ]

--- a/plugins/modules/cable.py
+++ b/plugins/modules/cable.py
@@ -232,11 +232,6 @@ def main():
     )
 
     required_if = [
-        (
-            "state",
-            "present",
-            ["termination_a_type", "termination_a", "termination_b_type", "termination_b"],
-        ),
         ("state", "absent", ["termination_a_type", "termination_a", "termination_b_type", "termination_b"]),
     ]
 

--- a/plugins/modules/circuit.py
+++ b/plugins/modules/circuit.py
@@ -165,7 +165,6 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["cid"]),
         ("state", "absent", ["cid"]),
     ]
 

--- a/plugins/modules/circuit.py
+++ b/plugins/modules/circuit.py
@@ -165,7 +165,7 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["cid", "status"]),
+        ("state", "present", ["cid"]),
         ("state", "absent", ["cid"]),
     ]
 

--- a/plugins/modules/circuit.py
+++ b/plugins/modules/circuit.py
@@ -164,11 +164,7 @@ def main():
         )
     )
 
-    required_if = [
-        ("state", "absent", ["cid"]),
-    ]
-
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     circuit = NautobotCircuitsModule(module, NB_CIRCUITS)
     circuit.run()

--- a/plugins/modules/cluster.py
+++ b/plugins/modules/cluster.py
@@ -145,11 +145,7 @@ def main():
         )
     )
 
-    required_if = [
-        ("state", "absent", ["name"]),
-    ]
-
-    module = AnsibleModule(argument_spec=argument_spec, required_if=required_if, supports_check_mode=True)
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     cluster = NautobotVirtualizationModule(module, NB_CLUSTERS)
     cluster.run()

--- a/plugins/modules/cluster.py
+++ b/plugins/modules/cluster.py
@@ -146,7 +146,6 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["name", "cluster_type"]),
         ("state", "absent", ["name"]),
     ]
 

--- a/plugins/modules/device.py
+++ b/plugins/modules/device.py
@@ -292,7 +292,6 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["name"]),
         ("state", "absent", ["name"]),
     ]
 

--- a/plugins/modules/device.py
+++ b/plugins/modules/device.py
@@ -292,7 +292,7 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["name", "status"]),
+        ("state", "present", ["name"]),
         ("state", "absent", ["name"]),
     ]
 

--- a/plugins/modules/device.py
+++ b/plugins/modules/device.py
@@ -291,11 +291,7 @@ def main():
         )
     )
 
-    required_if = [
-        ("state", "absent", ["name"]),
-    ]
-
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
     if module.params["name"] == "":
         module.params["name"] = str(uuid.uuid4())
 

--- a/plugins/modules/device_interface.py
+++ b/plugins/modules/device_interface.py
@@ -33,7 +33,7 @@ options:
   status:
     description:
       - The status of the interface
-      - Required if I(state=present) and using I(api_version) 1.4+
+      - Required if I(state=present) and the interface does not exist yet
     required: false
     type: raw
     version_added: "4.5.0"
@@ -285,11 +285,8 @@ def main():
             custom_fields=dict(required=False, type="dict"),
         )
     )
-    required_if = [
-        ("state", "present", ["status"]),
-    ]
 
-    module = AnsibleModule(argument_spec=argument_spec, required_if=required_if, supports_check_mode=True)
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     device_interface = NautobotDcimModule(module, NB_INTERFACES, remove_keys=["update_vc_child"])
     device_interface.run()

--- a/plugins/modules/ip_address.py
+++ b/plugins/modules/ip_address.py
@@ -218,7 +218,6 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["address", "parent"], True),
         ("state", "absent", ["address"]),
         ("state", "new", ["address", "parent"], True),
     ]

--- a/plugins/modules/ip_address.py
+++ b/plugins/modules/ip_address.py
@@ -218,7 +218,7 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["address", "parent", "status"], True),
+        ("state", "present", ["address", "parent"], True),
         ("state", "absent", ["address"]),
         ("state", "new", ["address", "parent"], True),
     ]

--- a/plugins/modules/ip_address.py
+++ b/plugins/modules/ip_address.py
@@ -218,7 +218,6 @@ def main():
     )
 
     required_if = [
-        ("state", "absent", ["address"]),
         ("state", "new", ["address", "parent"], True),
     ]
 

--- a/plugins/modules/location.py
+++ b/plugins/modules/location.py
@@ -235,7 +235,7 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["name", "location_type", "status"]),
+        ("state", "present", ["name", "location_type"]),
         ("state", "absent", ["id"]),
     ]
 

--- a/plugins/modules/location.py
+++ b/plugins/modules/location.py
@@ -235,7 +235,6 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["name", "location_type"]),
         ("state", "absent", ["id"]),
     ]
 

--- a/plugins/modules/power_feed.py
+++ b/plugins/modules/power_feed.py
@@ -195,7 +195,7 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["power_panel", "name", "status"]),
+        ("state", "present", ["power_panel", "name"]),
         ("state", "absent", ["power_panel", "name"]),
     ]
 

--- a/plugins/modules/power_feed.py
+++ b/plugins/modules/power_feed.py
@@ -195,7 +195,6 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["power_panel", "name"]),
         ("state", "absent", ["power_panel", "name"]),
     ]
 

--- a/plugins/modules/power_feed.py
+++ b/plugins/modules/power_feed.py
@@ -194,11 +194,7 @@ def main():
         )
     )
 
-    required_if = [
-        ("state", "absent", ["power_panel", "name"]),
-    ]
-
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     power_feed = NautobotDcimModule(module, NB_POWER_FEEDS)
     power_feed.run()

--- a/plugins/modules/prefix.py
+++ b/plugins/modules/prefix.py
@@ -249,7 +249,6 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["prefix", "parent"], True),
         ("state", "absent", ["prefix"]),
         ("first_available", "yes", ["parent"]),
     ]

--- a/plugins/modules/prefix.py
+++ b/plugins/modules/prefix.py
@@ -249,7 +249,7 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["prefix", "parent", "status"], True),
+        ("state", "present", ["prefix", "parent"], True),
         ("state", "absent", ["prefix"]),
         ("first_available", "yes", ["parent"]),
     ]

--- a/plugins/modules/rack.py
+++ b/plugins/modules/rack.py
@@ -217,11 +217,7 @@ def main():
         )
     )
 
-    required_if = [
-        ("state", "absent", ["name"]),
-    ]
-
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     rack = NautobotDcimModule(module, NB_RACKS)
     rack.run()

--- a/plugins/modules/rack.py
+++ b/plugins/modules/rack.py
@@ -218,7 +218,7 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["name", "status"]),
+        ("state", "present", ["name"]),
         ("state", "absent", ["name"]),
     ]
 

--- a/plugins/modules/rack.py
+++ b/plugins/modules/rack.py
@@ -218,7 +218,6 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["name"]),
         ("state", "absent", ["name"]),
     ]
 

--- a/plugins/modules/role.py
+++ b/plugins/modules/role.py
@@ -112,11 +112,7 @@ def main():
         )
     )
 
-    required_if = [
-        ("state", "absent", ["name"]),
-    ]
-
-    module = AnsibleModule(argument_spec=argument_spec, required_if=required_if, supports_check_mode=True)
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     role = NautobotDcimModule(module, NB_ROLES)
     role.run()

--- a/plugins/modules/role.py
+++ b/plugins/modules/role.py
@@ -113,7 +113,6 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["name", "content_types"], True),
         ("state", "absent", ["name"]),
     ]
 

--- a/plugins/modules/status.py
+++ b/plugins/modules/status.py
@@ -117,11 +117,7 @@ def main():
         )
     )
 
-    required_if = [
-        ("state", "absent", ["name"]),
-    ]
-
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     status = NautobotExtrasModule(module, NB_STATUS)
     status.run()

--- a/plugins/modules/status.py
+++ b/plugins/modules/status.py
@@ -118,7 +118,6 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["name", "content_types"]),
         ("state", "absent", ["name"]),
     ]
 

--- a/plugins/modules/virtual_machine.py
+++ b/plugins/modules/virtual_machine.py
@@ -196,7 +196,6 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["name"]),
         ("state", "absent", ["name"]),
     ]
 

--- a/plugins/modules/virtual_machine.py
+++ b/plugins/modules/virtual_machine.py
@@ -195,11 +195,7 @@ def main():
         )
     )
 
-    required_if = [
-        ("state", "absent", ["name"]),
-    ]
-
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     virtual_machine = NautobotVirtualizationModule(module, NB_VIRTUAL_MACHINES)
     virtual_machine.run()

--- a/plugins/modules/virtual_machine.py
+++ b/plugins/modules/virtual_machine.py
@@ -196,7 +196,7 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["name", "status"]),
+        ("state", "present", ["name"]),
         ("state", "absent", ["name"]),
     ]
 

--- a/plugins/modules/vlan.py
+++ b/plugins/modules/vlan.py
@@ -159,7 +159,7 @@ def main():
         )
     )
     required_if = [
-        ("state", "present", ["name", "status"]),
+        ("state", "present", ["name"]),
         ("state", "absent", ["name"]),
     ]
 

--- a/plugins/modules/vlan.py
+++ b/plugins/modules/vlan.py
@@ -158,11 +158,8 @@ def main():
             custom_fields=dict(required=False, type="dict"),
         )
     )
-    required_if = [
-        ("state", "absent", ["name"]),
-    ]
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     vlan = NautobotIpamModule(module, NB_VLANS)
     vlan.run()

--- a/plugins/modules/vlan.py
+++ b/plugins/modules/vlan.py
@@ -159,7 +159,6 @@ def main():
         )
     )
     required_if = [
-        ("state", "present", ["name"]),
         ("state", "absent", ["name"]),
     ]
 

--- a/plugins/modules/vm_interface.py
+++ b/plugins/modules/vm_interface.py
@@ -184,7 +184,6 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["name"]),
         ("state", "absent", ["name"]),
     ]
 

--- a/plugins/modules/vm_interface.py
+++ b/plugins/modules/vm_interface.py
@@ -183,11 +183,7 @@ def main():
         )
     )
 
-    required_if = [
-        ("state", "absent", ["name"]),
-    ]
-
-    module = AnsibleModule(argument_spec=argument_spec, required_if=required_if, supports_check_mode=True)
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     vm_interface = NautobotVirtualizationModule(module, NB_VM_INTERFACES)
     vm_interface.run()

--- a/plugins/modules/vm_interface.py
+++ b/plugins/modules/vm_interface.py
@@ -184,7 +184,7 @@ def main():
     )
 
     required_if = [
-        ("state", "present", ["name", "status"]),
+        ("state", "present", ["name"]),
         ("state", "absent", ["name"]),
     ]
 

--- a/tests/integration/targets/latest/tasks/cable.yml
+++ b/tests/integration/targets/latest/tasks/cable.yml
@@ -52,7 +52,6 @@
     termination_b:
       device: Test Nexus Child One
       name: Ethernet2/1
-    status: "Connected"
     state: present
   register: test_two
 
@@ -64,6 +63,7 @@
       - test_two['cable']['termination_a_id'] == nexus_parent_intf['key']
       - test_two['cable']['termination_b_type'] == "dcim.interface"
       - test_two['cable']['termination_b_id'] == nexus_child_intf['key']
+      - test_two['cable']['status'] == connected['key']
       - test_two['msg'] == "cable dcim.interface Ethernet1/1 <> dcim.interface Ethernet2/1 already exists"
 
 - name: "CABLE 3: Update Cable with other fields"
@@ -104,6 +104,44 @@
       - test_three['cable']['type'] == "mmf-om4"
       - test_three['cable']['status'] == planned['key']
       - test_three['cable']['label'] == "label123"
+      - test_three['cable']['color'] == "abcdef"
+      - test_three['cable']['length'] == 30
+      - test_three['cable']['length_unit'] == "m"
+      - test_three['msg'] == "cable dcim.interface Ethernet1/1 <> dcim.interface Ethernet2/1 updated"
+
+- name: "CABLE 3.1: Update Cable without status"
+  networktocode.nautobot.cable:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    termination_a_type: dcim.interface
+    termination_a:
+      device: Test Nexus One
+      name: Ethernet1/1
+    termination_b_type: dcim.interface
+    termination_b:
+      device: Test Nexus Child One
+      name: Ethernet2/1
+    type: mmf-om4
+    label: label1234
+    color: abcdef
+    length: 30
+    length_unit: m
+    state: present
+  register: test_three
+
+- name: "CABLE 3.1: ASSERT - Update Cable without status"
+  assert:
+    that:
+      - test_three is changed
+
+      - test_three['diff']['after']['label'] == "label1234"
+      - test_three['cable']['termination_a_type'] == "dcim.interface"
+      - test_three['cable']['termination_a_id'] == nexus_parent_intf['key']
+      - test_three['cable']['termination_b_type'] == "dcim.interface"
+      - test_three['cable']['termination_b_id'] == nexus_child_intf['key']
+      - test_three['cable']['type'] == "mmf-om4"
+      - test_three['cable']['status'] == planned['key']
+      - test_three['cable']['label'] == "label1234"
       - test_three['cable']['color'] == "abcdef"
       - test_three['cable']['length'] == 30
       - test_three['cable']['length_unit'] == "m"

--- a/tests/integration/targets/latest/tasks/cable.yml
+++ b/tests/integration/targets/latest/tasks/cable.yml
@@ -52,6 +52,7 @@
     termination_b:
       device: Test Nexus Child One
       name: Ethernet2/1
+    status: "Connected"
     state: present
   register: test_two
 
@@ -63,7 +64,6 @@
       - test_two['cable']['termination_a_id'] == nexus_parent_intf['key']
       - test_two['cable']['termination_b_type'] == "dcim.interface"
       - test_two['cable']['termination_b_id'] == nexus_child_intf['key']
-      - test_two['cable']['status'] == connected['key']
       - test_two['msg'] == "cable dcim.interface Ethernet1/1 <> dcim.interface Ethernet2/1 already exists"
 
 - name: "CABLE 3: Update Cable with other fields"

--- a/tests/integration/targets/latest/tasks/circuit.yml
+++ b/tests/integration/targets/latest/tasks/circuit.yml
@@ -89,6 +89,38 @@
       - test_three['circuit']['comments'] == "FAST CIRCUIT"
       - test_three['msg'] == "circuit Test Circuit One updated"
 
+- name: "PYNAUTOBOT_CIRCUIT 3.1: Update circuit without status"
+  networktocode.nautobot.circuit:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    cid: Test Circuit One
+    provider: Test Provider
+    circuit_type: Test Circuit Type
+    tenant: Test Tenant
+    install_date: "2018-12-25"
+    commit_rate: 10000
+    description: "Test circuit with updates"
+    comments: "FASTER CIRCUIT"
+    state: present
+  register: test_three
+
+- name: "PYNAUTOBOT_CIRCUIT 3.1: ASSERT - Update circuit without status"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['description'] == "Test circuit with updates"
+      - test_three['diff']['after']['comments'] == "FASTER CIRCUIT"
+      - test_three['circuit']['cid'] == "Test Circuit One"
+      - test_three['circuit']['provider'] == provider['key']
+      - test_three['circuit']['circuit_type'] == type['key']
+      - test_three['circuit']['status'] == planned['key']
+      - test_three['circuit']['tenant'] == tenant['key']
+      - test_three['circuit']['install_date'] == "2018-12-25"
+      - test_three['circuit']['commit_rate'] == 10000
+      - test_three['circuit']['description'] == "Test circuit with updates"
+      - test_three['circuit']['comments'] == "FASTER CIRCUIT"
+      - test_three['msg'] == "circuit Test Circuit One updated"
+
 - name: "PYNAUTOBOT_CIRCUIT 4: Delete provider within nautobot"
   networktocode.nautobot.circuit:
     url: "{{ nautobot_url }}"
@@ -108,6 +140,6 @@
       - test_four['circuit']['tenant'] == tenant['key']
       - test_four['circuit']['install_date'] == "2018-12-25"
       - test_four['circuit']['commit_rate'] == 10000
-      - test_four['circuit']['description'] == "Test circuit"
-      - test_four['circuit']['comments'] == "FAST CIRCUIT"
+      - test_four['circuit']['description'] == "Test circuit with updates"
+      - test_four['circuit']['comments'] == "FASTER CIRCUIT"
       - test_four['msg'] == "circuit Test Circuit One deleted"

--- a/tests/integration/targets/latest/tasks/device.yml
+++ b/tests/integration/targets/latest/tasks/device.yml
@@ -70,7 +70,6 @@
     token: "{{ nautobot_token }}"
     name: "R1"
     serial: "FXS1001"
-    status: "Staged"
     local_config_context_data:
       bgp_as: "65412"
     virtual_chassis: "VC1"
@@ -135,7 +134,6 @@
     token: "{{ nautobot_token }}"
     name: "R1-changed-name"
     serial: "FXS1001"
-    status: "Staged"
     query_params:
       - serial
     state: present
@@ -149,7 +147,7 @@
       - test_three_dot_two['device']['role'] == role['key']
       - test_three_dot_two['device']['device_type'] == device_type['key']
       - test_three_dot_two['device']['location'] == parent_location['key']
-      - test_three_dot_two['device']['status'] == staged['key']
+      - test_three_dot_two['device']['status'] == active['key']
       - test_three_dot_two['device']['serial'] == "FXS1001"
       - test_three_dot_two['msg'] == "device R1-changed-name updated"
 
@@ -248,7 +246,6 @@
     # This will test the UUID for ip4
     primary_ip4: "{{ ip4['key'] }}"
     primary_ip6: "2001::1:1/64"
-    status: "Active"
     state: present
   register: test_seven
 

--- a/tests/integration/targets/latest/tasks/ip_address.yml
+++ b/tests/integration/targets/latest/tasks/ip_address.yml
@@ -27,7 +27,6 @@
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
     address: 192.168.1.10/30
-    status: "Active"
     description: "Updated ip address"
     tags:
       - "Updated"
@@ -42,6 +41,7 @@
       - test_two['diff']['after']['tags'][0] == tag_updated['key']
       - test_two['msg'] == "ip_address 192.168.1.10/30 updated"
       - test_two['ip_address']['address'] == "192.168.1.10/30"
+      - test_two['ip_address']['status'] == active['key']
       - test_two['ip_address']['tags'][0] == tag_updated['key']
       - test_two['ip_address']['description'] == "Updated ip address"
   vars:

--- a/tests/integration/targets/latest/tasks/location.yml
+++ b/tests/integration/targets/latest/tasks/location.yml
@@ -50,7 +50,6 @@
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
     name: Test Location
-    status: Active
     location_type: "{{ parent_location_type['key'] }}"
     description: Test Location Description
   register: test_update
@@ -61,6 +60,7 @@
       - test_update is changed
       - test_update['diff']['before']['description'] == ""
       - test_update['diff']['after']['description'] == "Test Location Description"
+      - test_update['location']['status'] == active['key']
 
 - name: "4 - Create location with all parameters"
   networktocode.nautobot.location:

--- a/tests/integration/targets/latest/tasks/power_feed.yml
+++ b/tests/integration/targets/latest/tasks/power_feed.yml
@@ -90,6 +90,39 @@
       - test_three['power_feed']['comments'] == "totally normal power feed"
       - test_three['msg'] == "power_feed Power Feed updated"
 
+- name: "POWER_FEED 3.1: Update power_feed without status"
+  networktocode.nautobot.power_feed:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    name: Power Feed
+    power_panel: Test Power Panel
+    type: redundant
+    supply: dc
+    phase: three-phase
+    voltage: 400
+    amperage: 32
+    max_utilization: 25
+    comments: totally normal power feed, with updates
+    state: present
+  register: test_three
+
+- name: "POWER_FEED 3.1: ASSERT - Update power_feed without status"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['comments'] == "totally normal power feed, with updates"
+      - test_three['power_feed']['name'] == "Power Feed"
+      - test_three['power_feed']['power_panel'] == power_panel['key']
+      - test_three['power_feed']['status'] == offline['key']
+      - test_three['power_feed']['type'] == "redundant"
+      - test_three['power_feed']['supply'] == "dc"
+      - test_three['power_feed']['phase'] == "three-phase"
+      - test_three['power_feed']['voltage'] == 400
+      - test_three['power_feed']['amperage'] == 32
+      - test_three['power_feed']['max_utilization'] == 25
+      - test_three['power_feed']['comments'] == "totally normal power feed, with updates"
+      - test_three['msg'] == "power_feed Power Feed updated"
+
 - name: "POWER_FEED 4: Create Power Feed for Delete Test"
   networktocode.nautobot.power_feed:
     url: "{{ nautobot_url }}"

--- a/tests/integration/targets/latest/tasks/prefix.yml
+++ b/tests/integration/targets/latest/tasks/prefix.yml
@@ -75,6 +75,29 @@
       - test_three['prefix']['status'] == reserved['key']
       - test_three['prefix']['description'] == "This prefix has been updated"
 
+- name: "3.1 - Update 10.156.0.0/19 without status"
+  networktocode.nautobot.prefix:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    prefix: 10.156.0.0/19
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
+    description: "This prefix has been updated without providing a status"
+    state: present
+  register: test_three
+
+- name: "3.1 - ASSERT - Update 10.156.0.0/19 without status"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['description'] == "This prefix has been updated without providing a status"
+      - test_three['msg'] == "prefix 10.156.0.0/19 updated"
+      - test_three['prefix']['prefix'] == "10.156.0.0/19"
+      - test_three['prefix']['location'] == test_child_location['key']
+      - test_three['prefix']['status'] == reserved['key']
+      - test_three['prefix']['description'] == "This prefix has been updated without providing a status"
+
 - name: "4 - Delete prefix within nautobot"
   networktocode.nautobot.prefix:
     url: "{{ nautobot_url }}"

--- a/tests/integration/targets/latest/tasks/rack.yml
+++ b/tests/integration/targets/latest/tasks/rack.yml
@@ -110,7 +110,6 @@
     rack_group: "Parent Rack Group"
     facility_id: "EQUI10291"
     tenant: "Test Tenant"
-    status: Available
     serial: "FXS10001"
     asset_tag: "1234"
     width: 23
@@ -173,7 +172,6 @@
     rack_group: "Parent Rack Group"
     facility_id: "EQUI10291"
     tenant: "Test Tenant"
-    status: Available
     serial: "FXS10001"
     asset_tag: "1234"
     width: 23

--- a/tests/integration/targets/latest/tasks/virtual_machine.yml
+++ b/tests/integration/targets/latest/tasks/virtual_machine.yml
@@ -82,6 +82,35 @@
       - test_three['virtual_machine']['tags'][0] == tag_schnozzberry['key']
       - test_three['msg'] == "virtual_machine Test VM One updated"
 
+- name: "VIRTUAL_MACHINE 3.1: Update without status"
+  networktocode.nautobot.virtual_machine:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    name: "Test VM One"
+    cluster: "Test Cluster"
+    vcpus: 12
+    memory: 12
+    role: "Test VM Role"
+    tags:
+      - "Schnozzberry"
+    state: present
+  register: test_three
+
+- name: "VIRTUAL_MACHINE 3.1: ASSERT - Updated without status"
+  assert:
+    that:
+      - test_three is changed
+      - test_three['diff']['after']['vcpus'] == 12
+      - test_three['diff']['after']['memory'] == 12
+      - test_three['virtual_machine']['name'] == "Test VM One"
+      - test_three['virtual_machine']['cluster'] == test_cluster['key']
+      - test_three['virtual_machine']['vcpus'] == 12
+      - test_three['virtual_machine']['memory'] == 12
+      - test_three['virtual_machine']['status'] == planned['key']
+      - test_three['virtual_machine']['role'] == role['key']
+      - test_three['virtual_machine']['tags'][0] == tag_schnozzberry['key']
+      - test_three['msg'] == "virtual_machine Test VM One updated"
+
 - name: "VIRTUAL_MACHINE 4: ASSERT - Delete"
   networktocode.nautobot.virtual_machine:
     url: "{{ nautobot_url }}"
@@ -96,8 +125,8 @@
       - test_four is changed
       - test_four['virtual_machine']['name'] == "Test VM One"
       - test_four['virtual_machine']['cluster'] == test_cluster['key']
-      - test_four['virtual_machine']['vcpus'] == 8
-      - test_four['virtual_machine']['memory'] == 8
+      - test_four['virtual_machine']['vcpus'] == 12
+      - test_four['virtual_machine']['memory'] == 12
       - test_four['virtual_machine']['status'] == planned['key']
       - test_four['virtual_machine']['role'] == role['key']
       - test_four['virtual_machine']['tags'][0] == tag_schnozzberry['key']

--- a/tests/integration/targets/latest/tasks/vlan.yml
+++ b/tests/integration/targets/latest/tasks/vlan.yml
@@ -115,6 +115,39 @@
       - test_four['vlan']['tags'][0] == tag_schnozzberry['key']
       - test_four['msg'] == "vlan Test VLAN 500 updated"
 
+- name: "VLAN 4.1: Update without status"
+  networktocode.nautobot.vlan:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    name: "Test VLAN 500"
+    vid: 500
+    tenant: "Test Tenant"
+    vlan_group: "Test Vlan Group"
+    role: Network of care
+    description: "Updated description. More description information."
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
+    tags:
+      - "Schnozzberry"
+    state: present
+  register: test_four
+
+- name: "VLAN 4.1: ASSERT - Updated without status"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['after']['description'] == "Updated description. More description information."
+      - test_four['vlan']['name'] == "Test VLAN 500"
+      - test_four['vlan']['tenant'] == tenant['key']
+      - test_four['vlan']['location'] == test_location['key']
+      - test_four['vlan']['vlan_group'] == vlan_group['key']
+      - test_four['vlan']['status'] == reserved['key']
+      - test_four['vlan']['role'] == role['key']
+      - test_four['vlan']['description'] == "Updated description. More description information."
+      - test_four['vlan']['tags'][0] == tag_schnozzberry['key']
+      - test_four['msg'] == "vlan Test VLAN 500 updated"
+
 - name: "VLAN: ASSERT - IDEMPOTENT WITH VLAN_GROUP"
   networktocode.nautobot.vlan:
     url: "{{ nautobot_url }}"
@@ -125,7 +158,7 @@
     vlan_group: "Test Vlan Group"
     status: Reserved
     role: Network of care
-    description: Updated description
+    description: "Updated description. More description information."
     location:
       name: "Child Test Location"
       parent: "Parent Test Location"
@@ -206,6 +239,6 @@
       - test_six['vlan']['vlan_group'] == vlan_group['key']
       - test_six['vlan']['status'] == reserved['key']
       - test_six['vlan']['role'] == role['key']
-      - test_six['vlan']['description'] == "Updated description"
+      - test_six['vlan']['description'] == "Updated description. More description information."
       - test_six['vlan']['tags'][0] == tag_schnozzberry['key']
       - test_six['msg'] == "vlan Test VLAN 500 deleted"

--- a/tests/integration/targets/latest/tasks/vm_interface.yml
+++ b/tests/integration/targets/latest/tasks/vm_interface.yml
@@ -53,7 +53,6 @@
     token: "{{ nautobot_token }}"
     virtual_machine: "test100-vm"
     name: "Eth10"
-    status: "Active"
     enabled: false
     mtu: 9000
     mac_address: "00:00:00:AA:AA:01"
@@ -85,6 +84,7 @@
       - test_three['diff']['after']['tagged_vlans']|length == 2
       - test_three['diff']['after']['tags'][0] == tag_schnozzberry['key']
       - test_three['interface']['name'] == "Eth10"
+      - test_three['interface']['status'] == active['key']
       - test_three['interface']['virtual_machine'] == vm100['key']
       - test_three['interface']['enabled'] == false
       - test_three['interface']['mtu'] == 9000


### PR DESCRIPTION
## Closes [#251](https://github.com/nautobot/nautobot-ansible/issues/251)

Remove the `status` field requirement when state is `present`. This should eliminate the need to provide a status when updating non-status fields on an existing record.