### PR TITLE
Adds parent_location to QUERY_TYPES for query_params use with locations.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,5 +3,6 @@ docker-compose.yml
 *.md
 .env
 .venv
+venv/
 .vscode/
 .github/

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.pyc
 tests/output/*
 venv/
+.venv/
 .vscode/
 changelogs/.plugin-cache.yaml
 docs/_build/*

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -111,6 +111,7 @@ QUERY_TYPES = dict(
     master="name",
     nat_inside="address",
     nat_outside="address",
+    parent_location="name",
     parent_rack_group="name",
     parent_tenant_group="name",
     power_panel="name",

--- a/tests/integration/targets/latest/tasks/location.yml
+++ b/tests/integration/targets/latest/tasks/location.yml
@@ -184,3 +184,25 @@
       - test_eight['diff']['after']['state'] == "absent"
       - test_eight['location']['name'] == "Test Location"
       - "'deleted' in test_eight['msg']"
+
+- name: "9 - Use Parent Location Name"
+  networktocode.nautobot.location:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    name: Testing Parent Name Lookup
+    # Testing issue #303, where the location name lookup is exact instead of contains
+    # 'Parent Test Location' and 'Parent Test Location 2' are both valid parent locations
+    parent_location: "Parent Test Location"
+    status: Active
+    location_type: "{{ child_location_type['key'] }}"
+  register: test_parent_name
+
+- name: "9 - ASSERT"
+  assert:
+    that:
+      - test_parent_name is changed
+      - test_parent_name['diff']['before']['state'] == "absent"
+      - test_parent_name['diff']['after']['state'] == "present"
+      - test_parent_name['location']['name'] == "Testing Parent Name Lookup"
+      - test_parent_name['location']['status'] == active['key']
+      - test_parent_name['location']['location_type'] == child_location_type["key"]

--- a/tests/integration/targets/latest/tasks/lookup.yml
+++ b/tests/integration/targets/latest/tasks/lookup.yml
@@ -4,9 +4,9 @@
 ### PYNAUTOBOT_LOOKUP
 ##
 ##
-- name: "PYNAUTOBOT_LOOKUP 1: Lookup returns exactly five locations"
+- name: "PYNAUTOBOT_LOOKUP 1: Lookup returns exactly six locations"
   assert:
-    that: "query_result | count == 5"
+    that: "query_result | count == 6"
   vars:
     query_result: "{{ query('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token) }}"
 


### PR DESCRIPTION
Fixes #303 

After installing this change locally, I can successfully and repeatedly run the ansible snippet from issue #303:
```
TASK [locations : Create default locations] ********************************************************************************************************************************************************************
changed: [0.0.0.0] => (item={'name': 'Company', 'description': 'Company', 'parent_location': 'Global', 'location_type': 'Company', 'status': 'Active'})
changed: [0.0.0.0] => (item={'name': 'ABC', 'description': 'ABC Metro', 'parent_location': 'Company', 'location_type': 'Region', 'status': 'Active'})
changed: [0.0.0.0] => (item={'name': 'XYZ', 'description': 'XYZ Metro', 'parent_location': 'Company', 'location_type': 'Region', 'status': 'Active'})
changed: [0.0.0.0] => (item={'name': 'ABC1', 'description': 'ABC1 Data Center', 'parent_location': 'ABC', 'location_type': 'Site', 'status': 'Active'})
changed: [0.0.0.0] => (item={'name': 'XYZ1', 'description': 'XYZ1 Data Center', 'parent_location': 'XYZ', 'location_type': 'Site', 'status': 'Active'})
```