### PR TITLE
Changes location_type parent parameter to convert to ID

### DIFF
--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -112,6 +112,7 @@ QUERY_TYPES = dict(
     nat_inside="address",
     nat_outside="address",
     parent_location="name",
+    parent_location_type="name",
     parent_rack_group="name",
     parent_tenant_group="name",
     power_panel="name",
@@ -176,6 +177,7 @@ CONVERT_TO_ID = {
     "platform": "platforms",
     "parent_rack_group": "rack_groups",
     "parent_location": "locations",
+    "parent_location_type": "location_types",
     "parent_tenant_group": "tenant_groups",
     "power_panel": "power_panels",
     "power_port": "power_ports",
@@ -400,6 +402,7 @@ REQUIRED_ID_FIND = {
 CONVERT_KEYS = {
     "parent_rack_group": "parent",
     "parent_location": "parent",
+    "parent_location_type": "parent",
     "parent_tenant_group": "parent",
     "rear_port_template_position": "rear_port_position",
     "termination_a": "termination_a_id",

--- a/plugins/modules/location.py
+++ b/plugins/modules/location.py
@@ -56,6 +56,8 @@ options:
     required: false
     type: raw
   parent_location:
+    aliases:
+      - parent
     description:
       - The parent location this location should be tied to
     required: false
@@ -180,7 +182,7 @@ EXAMPLES = r"""
         contact_phone: 867-5309
         contact_email: jenny@example.com
         comments: "**This** is a `markdown` comment"
-        parent_location: My Location
+        parent: My Location
         state: present
 """
 
@@ -216,7 +218,7 @@ def main():
             status=dict(required=False, type="raw"),
             description=dict(required=False, type="str"),
             location_type=dict(required=False, type="raw"),
-            parent_location=dict(required=False, type="raw"),
+            parent_location=dict(required=False, type="raw", aliases=["parent"]),
             tenant=dict(required=False, type="raw"),
             facility=dict(required=False, type="str"),
             asn=dict(required=False, type="int"),

--- a/plugins/modules/location_type.py
+++ b/plugins/modules/location_type.py
@@ -35,7 +35,9 @@ options:
       - Location Type description
     required: false
     type: str
-  parent:
+  parent_location_type:
+    aliases:
+      - parent
     description:
       - The parent location type this location type should be tied to
     required: false
@@ -117,7 +119,7 @@ def main():
         dict(
             name=dict(required=True, type="str"),
             description=dict(required=False, type="str"),
-            parent=dict(required=False, type="raw"),
+            parent_location_type=dict(required=False, type="raw", aliases=["parent"]),
             nestable=dict(required=False, type="bool"),
             content_types=dict(required=False, type="list", elements="str"),
             custom_fields=dict(required=False, type="dict"),

--- a/plugins/modules/rack_group.py
+++ b/plugins/modules/rack_group.py
@@ -41,6 +41,8 @@ options:
     type: raw
     version_added: "3.0.0"
   parent_rack_group:
+    aliases:
+      - parent
     description:
       - The parent rack-group the rack group will be assigned to
     required: false
@@ -104,7 +106,7 @@ def main():
             name=dict(required=True, type="str"),
             description=dict(required=False, type="str"),
             location=dict(required=False, type="raw"),
-            parent_rack_group=dict(required=False, type="raw"),
+            parent_rack_group=dict(required=False, type="raw", aliases=["parent"]),
         )
     )
 

--- a/plugins/modules/tenant_group.py
+++ b/plugins/modules/tenant_group.py
@@ -35,6 +35,8 @@ options:
     type: str
     version_added: "3.0.0"
   parent_tenant_group:
+    aliases:
+      - parent
     description:
       - Name of the parent tenant group
     required: false
@@ -67,7 +69,7 @@ EXAMPLES = r"""
         url: http://nautobot.local
         token: thisIsMyToken
         name: Tenant Group ABC
-        parent_tenant_group: Customer Tenants
+        parent: Customer Tenants
         state: present
 
 """
@@ -101,7 +103,7 @@ def main():
         dict(
             name=dict(required=True, type="str"),
             description=dict(required=False, type="str"),
-            parent_tenant_group=dict(required=False, type="raw"),
+            parent_tenant_group=dict(required=False, type="raw", aliases=["parent"]),
         )
     )
 

--- a/tests/integration/targets/latest/tasks/location.yml
+++ b/tests/integration/targets/latest/tasks/location.yml
@@ -107,7 +107,7 @@
     status: Active
     description: Test Location 2 Description
     location_type: "{{ child_location_type['key'] }}"
-    parent_location: "{{ test_create_min['location']['id'] }}"
+    parent: "{{ test_create_min['location']['id'] }}"
     tenant: Test Tenant
     facility: EquinoxCA7
     asn: "65001"
@@ -192,7 +192,7 @@
     name: Testing Parent Name Lookup
     # Testing issue #303, where the location name lookup is exact instead of contains
     # 'Parent Test Location' and 'Parent Test Location 2' are both valid parent locations
-    parent_location: "Parent Test Location"
+    parent: "Parent Test Location"
     status: Active
     location_type: "{{ child_location_type['key'] }}"
   register: test_parent_name

--- a/tests/integration/targets/latest/tasks/location_type.yml
+++ b/tests/integration/targets/latest/tasks/location_type.yml
@@ -55,7 +55,7 @@
     token: "{{ nautobot_token }}"
     name: Test Location Type 2
     description: Test Location Type 2 Description
-    parent: "{{ test_create_min['location_type']['id'] }}"
+    parent: "{{ test_create_min['location_type']['name'] }}"
     nestable: "{{ true if nautobot_version is version('1.5', '>=') else omit }}"
     content_types:
       - "dcim.device"
@@ -80,7 +80,7 @@
     token: "{{ nautobot_token }}"
     name: Test Location Type 2
     description: Test Location Type 2 Description
-    parent: "{{ test_create_min['location_type']['id'] }}"
+    parent: "{{ test_create_min['location_type']['name'] }}"
     nestable: "{{ true if nautobot_version is version('1.5', '>=') else omit }}"
     content_types:
       - "dcim.device"

--- a/tests/integration/targets/latest/tasks/rack_group.yml
+++ b/tests/integration/targets/latest/tasks/rack_group.yml
@@ -6,6 +6,7 @@
 ##
 - set_fact:
     test_location: "{{ lookup('networktocode.nautobot.lookup', 'locations', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Child Test Location\" parent=\"Parent Test Location\"') }}"
+    parent_rack_group: "{{ lookup('networktocode.nautobot.lookup', 'rack-groups', api_endpoint=nautobot_url, token=nautobot_token, api_filter='name=\"Parent Rack Group\"') }}"
 
 - name: "RACK_GROUP 1: Necessary info creation"
   networktocode.nautobot.rack_group:
@@ -62,3 +63,51 @@
       - test_three['diff']['before']['state'] == "present"
       - test_three['diff']['after']['state'] == "absent"
       - test_three['msg'] == "rack_group Rack Group deleted"
+
+- name: "RACK_GROUP 4: Create child rack group"
+  networktocode.nautobot.rack_group:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    name: Test Rack Group
+    description: Test Rack Group Description
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
+    parent: Parent Rack Group
+    state: present
+  register: test_four
+
+- name: "RACK_GROUP 4: ASSERT - Create child rack group"
+  assert:
+    that:
+      - test_four is changed
+      - test_four['diff']['before']['state'] == "absent"
+      - test_four['diff']['after']['state'] == "present"
+      - test_four['rack_group']['name'] == "Test Rack Group"
+      - test_four['rack_group']['description'] == "Test Rack Group Description"
+      - test_four['rack_group']['location'] == test_location['key']
+      - test_four['rack_group']['parent'] == parent_rack_group['key']
+      - test_four['msg'] == "rack_group Test Rack Group created"
+
+- name: "RACK_GROUP 5: Create duplicate child rack group"
+  networktocode.nautobot.rack_group:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    name: Test Rack Group
+    description: Test Rack Group Description
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
+    parent: Parent Rack Group
+    state: present
+  register: test_five
+
+- name: "RACK_GROUP 5: ASSERT - Create duplicate child rack group"
+  assert:
+    that:
+      - not test_five['changed']
+      - test_five['rack_group']['name'] == "Test Rack Group"
+      - test_five['rack_group']['description'] == "Test Rack Group Description"
+      - test_five['rack_group']['location'] == test_location['key']
+      - test_five['rack_group']['parent'] == parent_rack_group['key']
+      - test_five['msg'] == "rack_group Test Rack Group already exists"

--- a/tests/integration/targets/latest/tasks/tenant_group.yml
+++ b/tests/integration/targets/latest/tasks/tenant_group.yml
@@ -13,7 +13,7 @@
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
     name: "Test Tenant Group Two"
-    parent_tenant_group: "Test Tenant Group"
+    parent: "Test Tenant Group"
   register: test_one
 
 - name: "1 - ASSERT"
@@ -31,7 +31,7 @@
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
     name: "Test Tenant Group Two"
-    parent_tenant_group: "Test Tenant Group"
+    parent: "Test Tenant Group"
   register: test_two
 
 - name: "2 - ASSERT"


### PR DESCRIPTION
Fixes: #305 

Since I converted the `parent` parameter this change is fully backwards compatible so we don't need to do a major version bump.

I also went ahead and added `parent` as an alias to all the modules that are actually "parent" in the API call for consistency as well as added/changed the tests to use the alias.