### PR TITLE
Update lookup_lookup.rst

### DIFF
--- a/docs/plugins/lookup_lookup.rst
+++ b/docs/plugins/lookup_lookup.rst
@@ -476,7 +476,7 @@ Examples
              manufactured by {{ item.value.device_type.manufacturer.name }}"
         loop: "{{ query('networktocode.nautobot.lookup', 'devices',
                         api_endpoint='http://localhost/',
-                        api_version='1.3',
+                        api_version='2.0',
                         token='<redacted>') }}"
 
     # This example uses an API Filter
@@ -489,7 +489,7 @@ Examples
              manufactured by {{ item.value.device_type.manufacturer.name }}"
         loop: "{{ query('networktocode.nautobot.lookup', 'devices',
                         api_endpoint='http://localhost/',
-                        api_version='1.3',
+                        api_version='2.0',
                         api_filter='role=management tags=Dell',
                         token='<redacted>') }}"
 
@@ -515,7 +515,7 @@ Examples
           msg: "{{ query('networktocode.nautobot.lookup', 'bgp_sessions',
                          api_filter='device=R1-Device',
                          api_endpoint='http://localhost/',
-                         api_version='1.3',
+                         api_version='2.0',
                          token='<redacted>',
                          plugin='mycustomstuff') }}"
 

--- a/docs/plugins/lookup_lookup.rst
+++ b/docs/plugins/lookup_lookup.rst
@@ -490,7 +490,7 @@ Examples
         loop: "{{ query('networktocode.nautobot.lookup', 'devices',
                         api_endpoint='http://localhost/',
                         api_version='1.3',
-                        api_filter='role=management tag=Dell',
+                        api_filter='role=management tags=Dell',
                         token='<redacted>') }}"
 
     # This example uses an API Filter with Depth set to get additional details from the lookup

--- a/plugins/lookup/lookup.py
+++ b/plugins/lookup/lookup.py
@@ -76,7 +76,7 @@ tasks:
          manufactured by {{ item.value.device_type.manufacturer.name }}"
     loop: "{{ query('networktocode.nautobot.lookup', 'devices',
                     api_endpoint='http://localhost/',
-                    api_version='1.3',
+                    api_version='2.0',
                     token='<redacted>') }}"
 
 # This example uses an API Filter
@@ -89,8 +89,8 @@ tasks:
          manufactured by {{ item.value.device_type.manufacturer.name }}"
     loop: "{{ query('networktocode.nautobot.lookup', 'devices',
                     api_endpoint='http://localhost/',
-                    api_version='1.3',
-                    api_filter='role=management tag=Dell',
+                    api_version='2.0',
+                    api_filter='role=management tags=Dell',
                     token='<redacted>') }}"
 
 # This example uses an API Filter with Depth set to get additional details from the lookup
@@ -115,7 +115,7 @@ tasks:
       msg: "{{ query('networktocode.nautobot.lookup', 'bgp_sessions',
                      api_filter='device=R1-Device',
                      api_endpoint='http://localhost/',
-                     api_version='1.3',
+                     api_version='2.0',
                      token='<redacted>',
                      plugin='mycustomstuff') }}"
 """


### PR DESCRIPTION
in nautobot v2, the filter for looking up tags is `tags` instead of `tag`. As it is, this example gives an error message that this is an unknown search filter:

```
fatal: [localhost]: FAILED! =>
  msg: 'An unhandled exception occurred while running the lookup plugin ''networktocode.nautobot.lookup''. Error was a <class ''ansible.errors.AnsibleError''>, original message: {"tag":["Unknown filter field"]}. {"tag":["Unknown filter field"]}'
```