### PR TITLE
ensures the idempotency for custom_fields

### DIFF
--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -913,8 +913,10 @@ class NautobotModule:
         serialized_nb_obj = self.nb_object.serialize()
         updated_obj = serialized_nb_obj.copy()
         updated_obj.update(data)
-        if serialized_nb_obj.get("custom_fields"):
-            serialized_nb_obj["custom_fields"] = {key: value for key, value in serialized_nb_obj["custom_fields"].items() if value is not None}
+        if "custom_fields" in serialized_nb_obj:
+            custom_fields = serialized_nb_obj.get("custom_fields", {})
+            shared_keys = custom_fields.keys() & data.get("custom_fields", {}).keys()
+            serialized_nb_obj["custom_fields"] = {key: custom_fields[key] for key in shared_keys if custom_fields[key] is not None}
         if serialized_nb_obj.get("tags") and data.get("tags"):
             serialized_nb_obj["tags"] = set(serialized_nb_obj["tags"])
             updated_obj["tags"] = set(data["tags"])

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -914,11 +914,7 @@ class NautobotModule:
         updated_obj = serialized_nb_obj.copy()
         updated_obj.update(data)
         if serialized_nb_obj.get("custom_fields"):
-            serialized_nb_obj["custom_fields"] = {
-                key: value
-                for key, value in serialized_nb_obj["custom_fields"].items()
-                if value is not None
-            }
+            serialized_nb_obj["custom_fields"] = {key: value for key, value in serialized_nb_obj["custom_fields"].items() if value is not None}
         if serialized_nb_obj.get("tags") and data.get("tags"):
             serialized_nb_obj["tags"] = set(serialized_nb_obj["tags"])
             updated_obj["tags"] = set(data["tags"])

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -911,12 +911,12 @@ class NautobotModule:
         Nautobot object and the Ansible diff.
         """
         serialized_nb_obj = self.nb_object.serialize()
-        updated_obj = serialized_nb_obj.copy()
-        updated_obj.update(data)
         if "custom_fields" in serialized_nb_obj:
             custom_fields = serialized_nb_obj.get("custom_fields", {})
             shared_keys = custom_fields.keys() & data.get("custom_fields", {}).keys()
             serialized_nb_obj["custom_fields"] = {key: custom_fields[key] for key in shared_keys if custom_fields[key] is not None}
+        updated_obj = serialized_nb_obj.copy()
+        updated_obj.update(data)
         if serialized_nb_obj.get("tags") and data.get("tags"):
             serialized_nb_obj["tags"] = set(serialized_nb_obj["tags"])
             updated_obj["tags"] = set(data["tags"])

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -913,6 +913,12 @@ class NautobotModule:
         serialized_nb_obj = self.nb_object.serialize()
         updated_obj = serialized_nb_obj.copy()
         updated_obj.update(data)
+        if serialized_nb_obj.get("custom_fields"):
+            serialized_nb_obj["custom_fields"] = {
+                key: value
+                for key, value in serialized_nb_obj["custom_fields"].items()
+                if value is not None
+            }
         if serialized_nb_obj.get("tags") and data.get("tags"):
             serialized_nb_obj["tags"] = set(serialized_nb_obj["tags"])
             updated_obj["tags"] = set(data["tags"])

--- a/tests/integration/nautobot-populate.py
+++ b/tests/integration/nautobot-populate.py
@@ -586,7 +586,13 @@ custom_fields = [
         "key": "my_selection_custom_field",
         "type": "select",
         "content_types": ["circuits.circuit"],
-    }
+    },
+    {
+        "label": "My Text Custom Field",
+        "key": "my_text_custom_field",
+        "type": "text",
+        "content_types": ["circuits.circuit"],
+    },
 ]
 created_custom_fields = make_nautobot_calls(nb.extras.custom_fields, custom_fields)
 

--- a/tests/integration/targets/latest/tasks/circuit.yml
+++ b/tests/integration/targets/latest/tasks/circuit.yml
@@ -138,7 +138,7 @@
     state: present
   register: test_four
 
-- name: "PYNAUTOBOT_CIRCUIT 3.1: ASSERT - Update circuit without status"
+- name: "PYNAUTOBOT_CIRCUIT 4: ASSERT - Update circuit with custom_field"
   assert:
     that:
       - test_four is changed
@@ -154,6 +154,29 @@
       - test_four['circuit']['description'] == "Test circuit with updates"
       - test_four['circuit']['comments'] == "FASTER CIRCUIT"
       - test_four['msg'] == "circuit Test Circuit One updated"
+
+- name: "PYNAUTOBOT_CIRCUIT 4.1: Verify circuit with custom_field idempotency"
+  networktocode.nautobot.circuit:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    cid: Test Circuit One
+    provider: Test Provider
+    circuit_type: Test Circuit Type
+    tenant: Test Tenant
+    install_date: "2018-12-25"
+    commit_rate: 10000
+    custom_fields:
+      my_text_custom_field: test
+    description: "Test circuit with updates"
+    comments: "FASTER CIRCUIT"
+    state: present
+  register: test_four
+
+- name: "PYNAUTOBOT_CIRCUIT 5: ASSERT - Verify custom_field idempotency"
+  assert:
+    that:
+      - not test_four['changed']
+      - test_four['circuit']['custom_fields']['my_text_custom_field']  == "test"
 
 - name: "PYNAUTOBOT_CIRCUIT 5: Delete provider within nautobot"
   networktocode.nautobot.circuit:

--- a/tests/integration/targets/latest/tasks/circuit.yml
+++ b/tests/integration/targets/latest/tasks/circuit.yml
@@ -121,19 +121,30 @@
       - test_three['circuit']['comments'] == "FASTER CIRCUIT"
       - test_three['msg'] == "circuit Test Circuit One updated"
 
-- name: "PYNAUTOBOT_CIRCUIT 4: Delete provider within nautobot"
+- name: "PYNAUTOBOT_CIRCUIT 4: Update circuit with custom_field"
   networktocode.nautobot.circuit:
     url: "{{ nautobot_url }}"
     token: "{{ nautobot_token }}"
     cid: Test Circuit One
-    state: absent
+    provider: Test Provider
+    circuit_type: Test Circuit Type
+    tenant: Test Tenant
+    install_date: "2018-12-25"
+    commit_rate: 10000
+    custom_fields:
+      my_text_custom_field: test
+    description: "Test circuit with updates"
+    comments: "FASTER CIRCUIT"
+    state: present
   register: test_four
 
-- name: "PYNAUTOBOT_CIRCUIT 4 : ASSERT - Delete"
+- name: "PYNAUTOBOT_CIRCUIT 3.1: ASSERT - Update circuit without status"
   assert:
     that:
       - test_four is changed
       - test_four['circuit']['cid'] == "Test Circuit One"
+      - test_four['diff']['after']['custom_fields']['my_text_custom_field']  == "test"
+      - test_four['circuit']['custom_fields']['my_text_custom_field']  == "test"
       - test_four['circuit']['provider'] == provider['key']
       - test_four['circuit']['circuit_type'] == type['key']
       - test_four['circuit']['status'] == planned['key']
@@ -142,4 +153,27 @@
       - test_four['circuit']['commit_rate'] == 10000
       - test_four['circuit']['description'] == "Test circuit with updates"
       - test_four['circuit']['comments'] == "FASTER CIRCUIT"
-      - test_four['msg'] == "circuit Test Circuit One deleted"
+      - test_four['msg'] == "circuit Test Circuit One updated"
+
+- name: "PYNAUTOBOT_CIRCUIT 5: Delete provider within nautobot"
+  networktocode.nautobot.circuit:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    cid: Test Circuit One
+    state: absent
+  register: test_five
+
+- name: "PYNAUTOBOT_CIRCUIT 5 : ASSERT - Delete"
+  assert:
+    that:
+      - test_five is changed
+      - test_five['circuit']['cid'] == "Test Circuit One"
+      - test_five['circuit']['provider'] == provider['key']
+      - test_five['circuit']['circuit_type'] == type['key']
+      - test_five['circuit']['status'] == planned['key']
+      - test_five['circuit']['tenant'] == tenant['key']
+      - test_five['circuit']['install_date'] == "2018-12-25"
+      - test_five['circuit']['commit_rate'] == 10000
+      - test_five['circuit']['description'] == "Test circuit with updates"
+      - test_five['circuit']['comments'] == "FASTER CIRCUIT"
+      - test_five['msg'] == "circuit Test Circuit One deleted"


### PR DESCRIPTION
This should ensure that the custom_field is idempotent, even when only a subset of fields is written

backport of https://github.com/netbox-community/ansible_modules/pull/839