### PR TITLE
Fixes converting list of strings to ID

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,13 @@ networktocode.nautobot Release Notes
 .. contents:: Topics
 
 
+v5.3.1
+======
+
+Minor Changes
+-------------
+- (#422) Fixed `admin_permission` module to properly convert list of groups to UUIDs
+
 v5.3.0
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -477,3 +477,7 @@ releases:
       - (#352) Added IPv6 support as the default IP version for `gql_inventory` plugin
       - (#415) Added `role` option to `vm_interface` module
       - (#416) Fixed `location_type` idempotency for `location` module
+  5.3.1:
+    changes:
+      minor_changes:
+      - (#422) Fixed `admin_permission` module to properly convert list of groups to UUIDs

--- a/docs/plugins/admin_group_module.rst
+++ b/docs/plugins/admin_group_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.admin_group module -- Create, update or delete admin grou
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/admin_permission_module.rst
+++ b/docs/plugins/admin_permission_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.admin_permission module -- Create, update or delete objec
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/admin_user_module.rst
+++ b/docs/plugins/admin_user_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.admin_user module -- Create, update or delete users withi
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/cable_module.rst
+++ b/docs/plugins/cable_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.cable module -- Create, update or delete cables within Na
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/circuit_module.rst
+++ b/docs/plugins/circuit_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.circuit module -- Create, update or delete circuits withi
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/circuit_termination_module.rst
+++ b/docs/plugins/circuit_termination_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.circuit_termination module -- Create, update or delete ci
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/circuit_type_module.rst
+++ b/docs/plugins/circuit_type_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.circuit_type module -- Create, update or delete circuit t
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/cluster_group_module.rst
+++ b/docs/plugins/cluster_group_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.cluster_group module -- Create, update or delete cluster 
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/cluster_module.rst
+++ b/docs/plugins/cluster_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.cluster module -- Create, update or delete clusters withi
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/cluster_type_module.rst
+++ b/docs/plugins/cluster_type_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.cluster_type module -- Create, update or delete cluster t
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/console_port_module.rst
+++ b/docs/plugins/console_port_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.console_port module -- Create, update or delete console p
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/console_port_template_module.rst
+++ b/docs/plugins/console_port_template_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.console_port_template module -- Create, update or delete 
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/console_server_port_module.rst
+++ b/docs/plugins/console_server_port_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.console_server_port module -- Create, update or delete co
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/console_server_port_template_module.rst
+++ b/docs/plugins/console_server_port_template_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.console_server_port_template module -- Create, update or 
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/contact_module.rst
+++ b/docs/plugins/contact_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.contact module -- Creates or removes contacts from Nautob
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/controller_module.rst
+++ b/docs/plugins/controller_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.controller module -- Create, update or delete controllers
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/custom_field_choice_module.rst
+++ b/docs/plugins/custom_field_choice_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.custom_field_choice module -- Creates or removes custom f
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/custom_field_module.rst
+++ b/docs/plugins/custom_field_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.custom_field module -- Creates or removes custom fields f
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/device_bay_module.rst
+++ b/docs/plugins/device_bay_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.device_bay module -- Create, update or delete device bays
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/device_bay_template_module.rst
+++ b/docs/plugins/device_bay_template_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.device_bay_template module -- Create, update or delete de
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/device_interface_module.rst
+++ b/docs/plugins/device_interface_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.device_interface module -- Creates or removes interfaces 
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/device_interface_template_module.rst
+++ b/docs/plugins/device_interface_template_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.device_interface_template module -- Creates or removes in
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/device_module.rst
+++ b/docs/plugins/device_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.device module -- Create, update or delete devices within 
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/device_redundancy_group_module.rst
+++ b/docs/plugins/device_redundancy_group_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.device_redundancy_group module -- Creates or removes devi
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/device_type_module.rst
+++ b/docs/plugins/device_type_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.device_type module -- Create, update or delete device typ
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/front_port_module.rst
+++ b/docs/plugins/front_port_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.front_port module -- Create, update or delete front ports
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/front_port_template_module.rst
+++ b/docs/plugins/front_port_template_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.front_port_template module -- Create, update or delete fr
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/gql_inventory_inventory.rst
+++ b/docs/plugins/gql_inventory_inventory.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.gql_inventory inventory -- Nautobot inventory source usin
 .. Collection note
 
 .. note::
-    This inventory plugin is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This inventory plugin is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -7,7 +7,7 @@
 Networktocode.Nautobot
 ======================
 
-Collection version 5.3.0
+Collection version 5.3.1
 
 .. contents::
    :local:

--- a/docs/plugins/inventory_inventory.rst
+++ b/docs/plugins/inventory_inventory.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.inventory inventory -- Nautobot inventory source
 .. Collection note
 
 .. note::
-    This inventory plugin is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This inventory plugin is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/inventory_item_module.rst
+++ b/docs/plugins/inventory_item_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.inventory_item module -- Creates or removes inventory ite
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/ip_address_module.rst
+++ b/docs/plugins/ip_address_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.ip_address module -- Creates or removes IP addresses from
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/ip_address_to_interface_module.rst
+++ b/docs/plugins/ip_address_to_interface_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.ip_address_to_interface module -- Creates or removes IP a
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/location_module.rst
+++ b/docs/plugins/location_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.location module -- Creates or removes locations from Naut
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/location_type_module.rst
+++ b/docs/plugins/location_type_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.location_type module -- Creates or removes location types
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/lookup_graphql_lookup.rst
+++ b/docs/plugins/lookup_graphql_lookup.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.lookup_graphql lookup -- Queries and returns elements fro
 .. Collection note
 
 .. note::
-    This lookup plugin is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This lookup plugin is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/lookup_lookup.rst
+++ b/docs/plugins/lookup_lookup.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.lookup lookup -- Queries and returns elements from Nautob
 .. Collection note
 
 .. note::
-    This lookup plugin is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This lookup plugin is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/manufacturer_module.rst
+++ b/docs/plugins/manufacturer_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.manufacturer module -- Create or delete manufacturers wit
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/namespace_module.rst
+++ b/docs/plugins/namespace_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.namespace module -- Creates or removes namespaces from Na
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/nautobot_server_module.rst
+++ b/docs/plugins/nautobot_server_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.nautobot_server module -- Manages Nautobot Server applica
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/platform_module.rst
+++ b/docs/plugins/platform_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.platform module -- Create or delete platforms within Naut
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/plugin_module.rst
+++ b/docs/plugins/plugin_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.plugin module -- CRUD operation on plugin objects
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/power_feed_module.rst
+++ b/docs/plugins/power_feed_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.power_feed module -- Create, update or delete power feeds
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/power_outlet_module.rst
+++ b/docs/plugins/power_outlet_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.power_outlet module -- Create, update or delete power out
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/power_outlet_template_module.rst
+++ b/docs/plugins/power_outlet_template_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.power_outlet_template module -- Create, update or delete 
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/power_panel_module.rst
+++ b/docs/plugins/power_panel_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.power_panel module -- Create, update or delete power pane
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/power_port_module.rst
+++ b/docs/plugins/power_port_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.power_port module -- Create, update or delete power ports
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/power_port_template_module.rst
+++ b/docs/plugins/power_port_template_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.power_port_template module -- Create, update or delete po
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/prefix_module.rst
+++ b/docs/plugins/prefix_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.prefix module -- Creates or removes prefixes from Nautobo
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/provider_module.rst
+++ b/docs/plugins/provider_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.provider module -- Create, update or delete providers wit
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/query_graphql_module.rst
+++ b/docs/plugins/query_graphql_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.query_graphql module -- Queries and returns elements from
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/rack_group_module.rst
+++ b/docs/plugins/rack_group_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.rack_group module -- Create, update or delete racks group
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/rack_module.rst
+++ b/docs/plugins/rack_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.rack module -- Create, update or delete racks within Naut
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/rear_port_module.rst
+++ b/docs/plugins/rear_port_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.rear_port module -- Create, update or delete rear ports w
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/rear_port_template_module.rst
+++ b/docs/plugins/rear_port_template_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.rear_port_template module -- Create, update or delete rea
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/relationship_association_module.rst
+++ b/docs/plugins/relationship_association_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.relationship_association module -- Creates or removes a r
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/rir_module.rst
+++ b/docs/plugins/rir_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.rir module -- Create, update or delete RIRs within Nautob
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/role_module.rst
+++ b/docs/plugins/role_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.role module -- Create, update or delete roles within Naut
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/route_target_module.rst
+++ b/docs/plugins/route_target_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.route_target module -- Creates or removes route targets f
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/service_module.rst
+++ b/docs/plugins/service_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.service module -- Creates or removes service from Nautobo
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/status_module.rst
+++ b/docs/plugins/status_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.status module -- Creates or removes status from Nautobot
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/tag_module.rst
+++ b/docs/plugins/tag_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.tag module -- Creates or removes tags from Nautobot
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/team_module.rst
+++ b/docs/plugins/team_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.team module -- Creates or removes teams from Nautobot
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/tenant_group_module.rst
+++ b/docs/plugins/tenant_group_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.tenant_group module -- Creates or removes tenant groups f
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/tenant_module.rst
+++ b/docs/plugins/tenant_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.tenant module -- Creates or removes tenants from Nautobot
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/virtual_chassis_module.rst
+++ b/docs/plugins/virtual_chassis_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.virtual_chassis module -- Create, update or delete virtua
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/virtual_machine_module.rst
+++ b/docs/plugins/virtual_machine_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.virtual_machine module -- Create, update or delete virtua
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/vlan_group_module.rst
+++ b/docs/plugins/vlan_group_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.vlan_group module -- Create, update or delete vlans group
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/vlan_location_module.rst
+++ b/docs/plugins/vlan_location_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.vlan_location module -- Create, update or delete Location
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/vlan_module.rst
+++ b/docs/plugins/vlan_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.vlan module -- Create, update or delete vlans within Naut
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/vm_interface_module.rst
+++ b/docs/plugins/vm_interface_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.vm_interface module -- Creates or removes interfaces from
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/docs/plugins/vrf_module.rst
+++ b/docs/plugins/vrf_module.rst
@@ -22,7 +22,7 @@ networktocode.nautobot.vrf module -- Create, update or delete vrfs within Nautob
 .. Collection note
 
 .. note::
-    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.0).
+    This module is part of the `networktocode.nautobot collection <https://galaxy.ansible.com/ui/repo/published/networktocode/nautobot/>`_ (version 5.3.1).
 
     It is not included in ``ansible-core``.
     To check whether it is installed, run :code:`ansible-galaxy collection list`.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: networktocode
 name: nautobot
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 5.3.0
+version: 5.3.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -886,7 +886,7 @@ class NautobotModule:
                         else:
                             # Reminder: this get checks the QUERY_TYPES constant above, if the item is not in the list
                             # of approved query types, then it defaults to a q search
-                            temp_dict = {QUERY_TYPES.get(k, "q"): search}
+                            temp_dict = {QUERY_TYPES.get(k, "q"): list_item}
 
                         query_id = self._nb_endpoint_get(nb_endpoint, temp_dict, k)
                         if query_id:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot_ansible_modules"
-version = "5.3.0"
+version = "5.3.1"
 description = "Ansible collection to interact with Nautobot's API"
 authors = ["Network to Code <opensource@networktocode.com>"]
 license = "Apache 2.0"

--- a/tests/integration/nautobot-populate.py
+++ b/tests/integration/nautobot-populate.py
@@ -86,7 +86,11 @@ admin_users = [{"username": "a_admin_user", "is_staff": True, "is_superuser": Tr
 created_admin_users = make_nautobot_calls(nb.users.users, admin_users)
 
 # Create Admin User Groups
-admin_groups = [{"name": "A Test Admin User Group"}]
+admin_groups = [
+    {"name": "A Test Admin User Group"},
+    {"name": "A Test Admin User Group 2"},
+    {"name": "A Test Admin User Group 3"},
+]
 created_admin_groups = make_nautobot_calls(nb.users.groups, admin_groups)
 
 # Create TENANT GROUPS

--- a/tests/integration/targets/regression-latest/tasks/main.yml
+++ b/tests/integration/targets/regression-latest/tasks/main.yml
@@ -240,3 +240,18 @@
       assert:
         that:
           - '"Invalid version" in test_invalid_api_version["msg"]'
+
+    - name: Verify that we can convert a list of strings to ID (Issue 421)
+      networktocode.nautobot.admin_permission:
+        url: "{{ nautobot_url }}"
+        token: "{{ nautobot_token }}"
+        name: "Regression Permission Test One"
+        groups:
+          - "A Test Admin User Group"
+          - "A Test Admin User Group 2"
+          - "A Test Admin User Group 3"
+        actions:
+          - view
+        enabled: true
+        object_types:
+          - "dcim.device"


### PR DESCRIPTION
Closes: #421 

If we are converting multiple items to ID and the input is a list of strings, instead of sending the query one item at a time (`list_item`) we were sending the full list of items each time (`search`):

https://github.com/nautobot/nautobot-ansible/blob/fa797c214cd9456423bb2910ec57236a36e9c717/plugins/module_utils/utils.py#L886-L889