### PR TITLE
Ensure `default_ip_version` is set correctly. Fix `add_ip_address` logic.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ v5.3.1
 Minor Changes
 -------------
 - (#422) Fixed `admin_permission` module to properly convert list of groups to UUIDs
-- (#426) Fixed setting of `default_ip_version` option. Fixed logic in `add_ip_address` that sets Ansible `host` values
+- (#427) Fixed setting of `default_ip_version` option. Fixed logic in `add_ip_address` that sets Ansible `host` values
 
 v5.3.0
 ======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ v5.3.1
 Minor Changes
 -------------
 - (#422) Fixed `admin_permission` module to properly convert list of groups to UUIDs
+- (#426) Fixed setting of `default_ip_version` option. Fixed logic in `add_ip_address` that sets Ansible `host` values
 
 v5.3.0
 ======

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -481,3 +481,4 @@ releases:
     changes:
       minor_changes:
       - (#422) Fixed `admin_permission` module to properly convert list of groups to UUIDs
+      - (#426) Fixed setting of `default_ip_version` option. Fixed logic in `add_ip_address` that sets Ansible `host` values

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -481,4 +481,4 @@ releases:
     changes:
       minor_changes:
       - (#422) Fixed `admin_permission` module to properly convert list of groups to UUIDs
-      - (#426) Fixed setting of `default_ip_version` option. Fixed logic in `add_ip_address` that sets Ansible `host` values
+      - (#427) Fixed setting of `default_ip_version` option. Fixed logic in `add_ip_address` that sets Ansible `host` values

--- a/plugins/inventory/gql_inventory.py
+++ b/plugins/inventory/gql_inventory.py
@@ -249,6 +249,7 @@ GROUP_BY = {
     "role": "name",
     "location": "id",
 }
+DEFAULT_IP_VERSION_CHOICES = ["IPv4", "ipv4", "IPv6", "ipv6"]
 
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
@@ -278,15 +279,15 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # Check to see what the primary IP host addition is, first case is IPv4, which is the default
         order_of_preference = ["primary_ip4"]
 
-        # if default_ip_version is IPv4, prepend, else add to the end
+        # if default_ip_version is IPv6, prepend, else add to the end
         if default_ip_version.lower() == "ipv6":
             order_of_preference.insert(0, "primary_ip6")
         else:
             order_of_preference.append("primary_ip6")
 
-        # Check of the address types in the order preference and if it find the first one, add that primary IP to the host
+        # Check of the address types in the order of preference and if it finds the first one, add that primary IP to the host
         for address_type in order_of_preference:
-            if address_type in device and device[address_type].get("host"):
+            if address_type in device and device[address_type] and device[address_type].get("host"):
                 self.add_variable(device["name"], device[address_type]["host"], "ansible_host")
                 return
 
@@ -457,6 +458,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if token:
             self.headers.update({"Authorization": "Token %s" % token})
 
+        self.default_ip_version = self.get_option("default_ip_version")
+        if self.default_ip_version not in DEFAULT_IP_VERSION_CHOICES:
+            raise AnsibleError(f"Invalid choice for default_ip_version: {self.default_ip_version}")
         self.gql_query = self.get_option("query")
         self.group_by = self.get_option("group_by")
         self.follow_redirects = self.get_option("follow_redirects")

--- a/tests/integration/targets/inventory/files/test_2.3-3.json
+++ b/tests/integration/targets/inventory/files/test_2.3-3.json
@@ -117,7 +117,7 @@
                                     "custom_fields": {},
                                     "date_allocated": null,
                                     "description": "",
-                                    "display": "172.16.0.0/12",
+                                    "display": "172.16.0.0/12: Global",
                                     "ip_version": 4,
                                     "namespace": {
                                         "custom_fields": {},
@@ -274,7 +274,7 @@
                                     "custom_fields": {},
                                     "date_allocated": null,
                                     "description": "",
-                                    "display": "172.16.0.0/12",
+                                    "display": "172.16.0.0/12: Global",
                                     "ip_version": 4,
                                     "namespace": {
                                         "custom_fields": {},
@@ -742,7 +742,7 @@
                                     "custom_fields": {},
                                     "date_allocated": null,
                                     "description": "",
-                                    "display": "172.16.0.0/12",
+                                    "display": "172.16.0.0/12: Global",
                                     "ip_version": 4,
                                     "namespace": {
                                         "custom_fields": {},
@@ -903,7 +903,7 @@
                                     "custom_fields": {},
                                     "date_allocated": null,
                                     "description": "",
-                                    "display": "2001::/64",
+                                    "display": "2001::/64: Global",
                                     "ip_version": 6,
                                     "namespace": {
                                         "custom_fields": {},

--- a/tests/integration/targets/inventory/files/test_2.3-3_options_flatten.json
+++ b/tests/integration/targets/inventory/files/test_2.3-3_options_flatten.json
@@ -113,7 +113,7 @@
                                     "custom_fields": {},
                                     "date_allocated": null,
                                     "description": "",
-                                    "display": "172.16.0.0/12",
+                                    "display": "172.16.0.0/12: Global",
                                     "ip_version": 4,
                                     "namespace": {
                                         "custom_fields": {},
@@ -270,7 +270,7 @@
                                     "custom_fields": {},
                                     "date_allocated": null,
                                     "description": "",
-                                    "display": "172.16.0.0/12",
+                                    "display": "172.16.0.0/12: Global",
                                     "ip_version": 4,
                                     "namespace": {
                                         "custom_fields": {},
@@ -728,7 +728,7 @@
                                     "custom_fields": {},
                                     "date_allocated": null,
                                     "description": "",
-                                    "display": "172.16.0.0/12",
+                                    "display": "172.16.0.0/12: Global",
                                     "ip_version": 4,
                                     "namespace": {
                                         "custom_fields": {},
@@ -889,7 +889,7 @@
                                     "custom_fields": {},
                                     "date_allocated": null,
                                     "description": "",
-                                    "display": "2001::/64",
+                                    "display": "2001::/64: Global",
                                     "ip_version": 6,
                                     "namespace": {
                                         "custom_fields": {},

--- a/tests/integration/targets/inventory/files/test_2.3-3_plurals.json
+++ b/tests/integration/targets/inventory/files/test_2.3-3_plurals.json
@@ -137,7 +137,7 @@
                                     "custom_fields": {},
                                     "date_allocated": null,
                                     "description": "",
-                                    "display": "172.16.0.0/12",
+                                    "display": "172.16.0.0/12: Global",
                                     "ip_version": 4,
                                     "namespace": {
                                         "custom_fields": {},
@@ -294,7 +294,7 @@
                                     "custom_fields": {},
                                     "date_allocated": null,
                                     "description": "",
-                                    "display": "172.16.0.0/12",
+                                    "display": "172.16.0.0/12: Global",
                                     "ip_version": 4,
                                     "namespace": {
                                         "custom_fields": {},
@@ -791,7 +791,7 @@
                                     "custom_fields": {},
                                     "date_allocated": null,
                                     "description": "",
-                                    "display": "172.16.0.0/12",
+                                    "display": "172.16.0.0/12: Global",
                                     "ip_version": 4,
                                     "namespace": {
                                         "custom_fields": {},
@@ -952,7 +952,7 @@
                                     "custom_fields": {},
                                     "date_allocated": null,
                                     "description": "",
-                                    "display": "2001::/64",
+                                    "display": "2001::/64: Global",
                                     "ip_version": 6,
                                     "namespace": {
                                         "custom_fields": {},

--- a/tests/unit/inventory/test_graphql.py
+++ b/tests/unit/inventory/test_graphql.py
@@ -172,6 +172,26 @@ def test_add_ip_address_no_ipv6(inventory_fixture, device_data):
     assert mydevice_host.vars.get("ansible_host") == "10.10.10.10"
 
 
+def test_add_ip_address_ipv4_none(inventory_fixture, device_data):
+    """Regression bug test for issue #426."""
+    # Set the primary_ip4 to None
+    device_data["primary_ip4"] = None
+    try:
+        inventory_fixture.add_ip_address(device_data, default_ip_version="ipv4")
+    except AttributeError:
+        pytest.fail("Hit regression bug, see issue #426.")
+
+
+def test_add_ip_address_ipv6_none(inventory_fixture, device_data):
+    """Regression bug test for issue #426."""
+    # Set the primary_ip6 to None
+    device_data["primary_ip6"] = None
+    try:
+        inventory_fixture.add_ip_address(device_data, default_ip_version="ipv6")
+    except AttributeError:
+        pytest.fail("Hit regression bug, see issue #426.")
+
+
 def test_ansible_platform(inventory_fixture, device_data):
     inventory_fixture.group_by = ["location"]
     inventory_fixture.create_groups(device_data)


### PR DESCRIPTION
- Fixed setting of `default_ip_version` option. Closes #424 
- Fixed logic in `add_ip_address` that sets Ansible `host` values. Closes #426 