### PR TITLE
Fixes inventory 2.3 tests

### DIFF
--- a/tests/integration/targets/inventory/files/test_2.3-3.json
+++ b/tests/integration/targets/inventory/files/test_2.3-3.json
@@ -117,7 +117,7 @@
                                     "custom_fields": {},
                                     "date_allocated": null,
                                     "description": "",
-                                    "display": "172.16.0.0/12",
+                                    "display": "172.16.0.0/12: Global",
                                     "ip_version": 4,
                                     "namespace": {
                                         "custom_fields": {},
@@ -274,7 +274,7 @@
                                     "custom_fields": {},
                                     "date_allocated": null,
                                     "description": "",
-                                    "display": "172.16.0.0/12",
+                                    "display": "172.16.0.0/12: Global",
                                     "ip_version": 4,
                                     "namespace": {
                                         "custom_fields": {},
@@ -742,7 +742,7 @@
                                     "custom_fields": {},
                                     "date_allocated": null,
                                     "description": "",
-                                    "display": "172.16.0.0/12",
+                                    "display": "172.16.0.0/12: Global",
                                     "ip_version": 4,
                                     "namespace": {
                                         "custom_fields": {},
@@ -903,7 +903,7 @@
                                     "custom_fields": {},
                                     "date_allocated": null,
                                     "description": "",
-                                    "display": "2001::/64",
+                                    "display": "2001::/64: Global",
                                     "ip_version": 6,
                                     "namespace": {
                                         "custom_fields": {},

--- a/tests/integration/targets/inventory/files/test_2.3-3_options_flatten.json
+++ b/tests/integration/targets/inventory/files/test_2.3-3_options_flatten.json
@@ -113,7 +113,7 @@
                                     "custom_fields": {},
                                     "date_allocated": null,
                                     "description": "",
-                                    "display": "172.16.0.0/12",
+                                    "display": "172.16.0.0/12: Global",
                                     "ip_version": 4,
                                     "namespace": {
                                         "custom_fields": {},
@@ -270,7 +270,7 @@
                                     "custom_fields": {},
                                     "date_allocated": null,
                                     "description": "",
-                                    "display": "172.16.0.0/12",
+                                    "display": "172.16.0.0/12: Global",
                                     "ip_version": 4,
                                     "namespace": {
                                         "custom_fields": {},
@@ -728,7 +728,7 @@
                                     "custom_fields": {},
                                     "date_allocated": null,
                                     "description": "",
-                                    "display": "172.16.0.0/12",
+                                    "display": "172.16.0.0/12: Global",
                                     "ip_version": 4,
                                     "namespace": {
                                         "custom_fields": {},
@@ -889,7 +889,7 @@
                                     "custom_fields": {},
                                     "date_allocated": null,
                                     "description": "",
-                                    "display": "2001::/64",
+                                    "display": "2001::/64: Global",
                                     "ip_version": 6,
                                     "namespace": {
                                         "custom_fields": {},

--- a/tests/integration/targets/inventory/files/test_2.3-3_plurals.json
+++ b/tests/integration/targets/inventory/files/test_2.3-3_plurals.json
@@ -137,7 +137,7 @@
                                     "custom_fields": {},
                                     "date_allocated": null,
                                     "description": "",
-                                    "display": "172.16.0.0/12",
+                                    "display": "172.16.0.0/12: Global",
                                     "ip_version": 4,
                                     "namespace": {
                                         "custom_fields": {},
@@ -294,7 +294,7 @@
                                     "custom_fields": {},
                                     "date_allocated": null,
                                     "description": "",
-                                    "display": "172.16.0.0/12",
+                                    "display": "172.16.0.0/12: Global",
                                     "ip_version": 4,
                                     "namespace": {
                                         "custom_fields": {},
@@ -791,7 +791,7 @@
                                     "custom_fields": {},
                                     "date_allocated": null,
                                     "description": "",
-                                    "display": "172.16.0.0/12",
+                                    "display": "172.16.0.0/12: Global",
                                     "ip_version": 4,
                                     "namespace": {
                                         "custom_fields": {},
@@ -952,7 +952,7 @@
                                     "custom_fields": {},
                                     "date_allocated": null,
                                     "description": "",
-                                    "display": "2001::/64",
+                                    "display": "2001::/64: Global",
                                     "ip_version": 6,
                                     "namespace": {
                                         "custom_fields": {},


### PR DESCRIPTION
This PR fixes inventory tests for 2.3. This changed was introduced in Nautobot v2.3.3 with this PR: https://github.com/nautobot/nautobot/pull/6190