### PR TITLE
Add ansible-doc strings to graphql.py

### DIFF
--- a/plugins/filter/graphql.py
+++ b/plugins/filter/graphql.py
@@ -8,6 +8,37 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
+DOCUMENTATION = """
+name: graphql_string
+author: Mikhail Yohman (@FragmentedPacket)
+version_added: "3.4.0"
+short_description: The graphql_string filter plugin.
+description:
+  - The filter converts a dictionary to a GraphQL string.
+options:
+  query:
+    description:
+      - A dictionary mapping to the GraphQL call to be made.
+    type: dict
+    required: True
+  start:
+    description:
+      - The starting indentation when compiling the string.
+    type: int
+    required: False
+"""
+
+RETURN = """
+graphql_string:
+  description: GraphQL query string
+  returned: always
+  type: str
+"""
+
+EXAMPLES = """
+"""
+
+
 def build_graphql_filter_string(filter: dict) -> str:
     """Takes a dictionary and builds a graphql filter
 

--- a/plugins/filter/graphql.py
+++ b/plugins/filter/graphql.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 name: graphql_string
 author: Mikhail Yohman (@FragmentedPacket)
 version_added: "3.4.0"
@@ -28,34 +28,34 @@ options:
     required: False
 """
 
-RETURN = """
+RETURN = r"""
 graphql_string:
   description: GraphQL query string
   returned: always
   type: str
 """
 
-EXAMPLES = """
+EXAMPLES = r"""
 # Code:
-      set_fact:
-        gql_query: "{{ gql_dict | networktocode.nautobot.graphql_string }}"
-      vars:
-        gql_dict:
-          query:
-            devices:
-              name:
-              primary_ip4:
-                host:
-              platform:
-                napalm_driver:
+- set_fact:
+    gql_query: "{{ gql_dict | networktocode.nautobot.graphql_string }}"
+  vars:
+    gql_dict:
+      query:
+        devices:
+          name:
+          primary_ip4:
+            host:
+          platform:
+            napalm_driver:
 
 # Output:
-ok: [localhost] => {
-    "ansible_facts": {
-        "gql_query": "query {\n  devices {\n    name\n    primary_ip4 {\n      host\n    }\n    platform {\n      napalm_driver\n    }\n  }\n}"
-    },
-    "changed": false
-}
+# ok: [localhost] => {
+#     "ansible_facts": {
+#         "gql_query": "query {\n  devices {\n    name\n    primary_ip4 {\n      host\n    }\n    platform {\n      napalm_driver\n    }\n  }\n}"
+#     },
+#     "changed": false
+# }
 """
 
 

--- a/plugins/filter/graphql.py
+++ b/plugins/filter/graphql.py
@@ -36,6 +36,26 @@ graphql_string:
 """
 
 EXAMPLES = """
+# Code:
+      set_fact:
+        gql_query: "{{ gql_dict | networktocode.nautobot.graphql_string }}"
+      vars:
+        gql_dict:
+          query:
+            devices:
+              name:
+              primary_ip4:
+                host:
+              platform:
+                napalm_driver:
+
+# Output:
+ok: [localhost] => {
+    "ansible_facts": {
+        "gql_query": "query {\n  devices {\n    name\n    primary_ip4 {\n      host\n    }\n    platform {\n      napalm_driver\n    }\n  }\n}"
+    },
+    "changed": false
+}
 """
 
 


### PR DESCRIPTION
Fixes #435 

- [x] If anyone can provide a usage example of this filter it would be fantastic!
- [ ] Validate metadata with maintainers (did my best to extract correct details from git history, please confirm)

Running `ansible-doc -t filter networktocode.nautobot.graphql_string` yields:

```
> NETWORKTOCODE.NAUTOBOT.GRAPHQL_STRING    (/Users/cmsirbu/x/dev/ntc/projects/mkdocs-ansible-collection/collections/ansible_collections/networktoco>

        The filter converts a dictionary to a GraphQL string.

ADDED IN: version 3.4.0 of networktocode.nautobot

OPTIONS (= is mandatory):

= query
        A dictionary mapping to the GraphQL call to be made.
        type: dict

- start
        The starting indentation when compiling the string.
        default: null
        type: int


AUTHOR: Mikhail Yohman (@FragmentedPacket)

NAME: graphql_string

EXAMPLES:

# Code:
- set_fact:
    gql_query: "{{ gql_dict | networktocode.nautobot.graphql_string }}"
  vars:
    gql_dict:
      query:
        devices:
          name:
          primary_ip4:
            host:
          platform:
            napalm_driver:

# Output:
# ok: [localhost] => {
#     "ansible_facts": {
#         "gql_query": "query {\n  devices {\n    name\n    primary_ip4 {\n      host\n    }\n    platform {\n      napalm_driver\n    }\n  }\n}"
#     },
#     "changed": false
# }


RETURN VALUES:
- graphql_string
        GraphQL query string
        returned: always
        type: str
```

Allows for successful docs renders like below (future spoilers for collection docs 😄 ):

![Screen Shot 2024-10-31 at 17 00 26](https://github.com/user-attachments/assets/300145bb-f92f-4557-bee4-9b0a5e095973)
