### PR TITLE
Adds parent_location_type allowed query types

### DIFF
--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -4,13 +4,13 @@ ARG PYTHON_VER
 FROM ghcr.io/nautobot/nautobot:${NAUTOBOT_VER}-py${PYTHON_VER} as nautobot
 
 # Copy in the requirements file
-COPY ./development/requirements.txt /opt/nautobot/requirements.txt
+COPY --chown=nautobot:nautobot ./development/requirements.txt /opt/nautobot/requirements.txt
 
 # Install the requirements
 RUN pip install -r /opt/nautobot/requirements.txt
 
 # Copy in the jobs
-COPY ./development/jobs /opt/nautobot/jobs
+COPY --chown=nautobot:nautobot ./development/jobs /opt/nautobot/jobs
 
 # Copy in the development configuration file
-COPY ./development/nautobot_config.py /opt/nautobot/nautobot_config.py
+COPY --chown=nautobot:nautobot ./development/nautobot_config.py /opt/nautobot/nautobot_config.py

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -418,6 +418,7 @@ ALLOWED_QUERY_PARAMS = {
     "namespace": set(["name"]),
     "nat_inside": set(["namespace", "address"]),
     "object_metadata": set(["metadata_type", "assigned_object_type", "assigned_object_id", "value"]),
+    "parent_location_type": set(["name"]),
     "parent_module_bay": set(["name", "parent_device", "parent_module"]),
     "parent_module": set(["module_type", "parent_module_bay"]),
     "parent_rack_group": set(["name"]),

--- a/tests/integration/targets/latest/tasks/location_type.yml
+++ b/tests/integration/targets/latest/tasks/location_type.yml
@@ -55,7 +55,8 @@
     token: "{{ nautobot_token }}"
     name: Test Location Type 2
     description: Test Location Type 2 Description
-    parent: "{{ test_create_min['location_type']['name'] }}"
+    parent:
+      name: "{{ test_create_min['location_type']['name'] }}"
     nestable: "{{ true if nautobot_version is version('1.5', '>=') else omit }}"
     content_types:
       - "dcim.device"
@@ -80,7 +81,8 @@
     token: "{{ nautobot_token }}"
     name: Test Location Type 2
     description: Test Location Type 2 Description
-    parent: "{{ test_create_min['location_type']['name'] }}"
+    parent:
+      name: "{{ test_create_min['location_type']['name'] }}"
     nestable: "{{ true if nautobot_version is version('1.5', '>=') else omit }}"
     content_types:
       - "dcim.device"


### PR DESCRIPTION
Closes: #463 

Also, my tests were failing locally due to the jobs folder being copied in as the root user instead of `nautobot`, so I added the `--chown` flag to the copy commands to fix that.