### PR TITLE
Fix documentation for lookup_graphql.py

### DIFF
--- a/plugins/lookup/lookup_graphql.py
+++ b/plugins/lookup/lookup_graphql.py
@@ -80,7 +80,7 @@ EXAMPLES = """
       graph_variables:
         location_name: DEN
       query_string: |
-        query ($location_name:String!) {
+        query ($location_name:[String]) {
             locations (name: $location_name) {
             id
             name


### PR DESCRIPTION
Getting this error for similar query for Devices: `'Variable \"device_name\" of type \"String!\" used in position expecting type \"[String]\".'`