### PR TITLE
Added the ability to look up IP Addresses by address and namespace for ip_address_to_interface module #314

### DIFF
--- a/changelogs/fragments/314.added
+++ b/changelogs/fragments/314.added
@@ -1,0 +1,1 @@
+Added the ability to look up IP Addresses by `address` and `namespace` for `ip_address_to_interface` module.

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -219,6 +219,7 @@ CONVERT_TO_ID = {
     "installed_device": "devices",
     "interface": "interfaces",
     "interface_template": "interface_templates",
+    "ip_address": "ip_addresses",
     "ip_addresses": "ip_addresses",
     "ipaddresses": "ip_addresses",
     "job": "jobs",

--- a/plugins/modules/ip_address_to_interface.py
+++ b/plugins/modules/ip_address_to_interface.py
@@ -19,6 +19,7 @@ notes:
 author:
   - Mikhail Yohman (@FragmentedPacket)
   - Anthony Ruhier (@Anthony25)
+  - Chris Tomkins (@ChrisTomkins25)
 version_added: "5.0.0"
 extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
@@ -60,24 +61,24 @@ EXAMPLES = r"""
       networktocode.nautobot.ip_address_to_interface:
         url: "{{ nautobot_url }}"
         token: "{{ nautobot_token }}"
-        ip_address: "{{ ip_address['key'] }}"
+        ip_address:
+          address: "10.100.0.1/32"
+          namespace: "Global"
         interface:
           name: GigabitEthernet4
           device: test100
-      vars:
-        ip_address: "{{ lookup('networktocode.nautobot.lookup', 'ip-addresses', api_endpoint=nautobot_url, token=nautobot_token, api_filter='address=10.100.0.1/32') }}"
 
     - name: "Delete IP address on GigabitEthernet4 - test100"
       networktocode.nautobot.ip_address_to_interface:
         url: "{{ nautobot_url }}"
         token: "{{ nautobot_token }}"
-        ip_address: "{{ ip_address['key'] }}"
+        ip_address:
+          address: "10.100.0.1/32"
+          namespace: "Global"
         interface:
           name: GigabitEthernet4
           device: test100
         state: absent
-      vars:
-        ip_address: "{{ lookup('networktocode.nautobot.lookup', 'ip-addresses', api_endpoint=nautobot_url, token=nautobot_token, api_filter='address=10.100.0.1/32') }}"
 
 """
 

--- a/tests/integration/targets/latest/tasks/ip_address_to_interface.yml
+++ b/tests/integration/targets/latest/tasks/ip_address_to_interface.yml
@@ -116,10 +116,73 @@
     state: absent
   register: test_six
 
-- name: "3 - ASSERT"
+- name: "6 - ASSERT"
   assert:
     that:
       - test_six is changed
       - test_six['diff']['before']['state'] == "present"
       - test_six['diff']['after']['state'] == "absent"
       - "'deleted' in test_six['msg']"
+
+- name: "7 - Add IP address on GigabitEthernet4 - test100 (with ip_address dict)"
+  networktocode.nautobot.ip_address_to_interface:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    ip_address:
+      address: "10.100.0.1/32"
+      namespace: "Global"
+    interface:
+      name: GigabitEthernet4
+      device: test100
+  register: test_seven
+
+- name: "7 - ASSERT"
+  assert:
+    that:
+      - test_seven is changed
+      - test_seven['diff']['before']['state'] == "absent"
+      - test_seven['diff']['after']['state'] == "present"
+      - "'created' in test_seven['msg']"
+      - test_seven['ip_address_to_interface']['ip_address'] == ip_address_dev['key']
+      - test_seven['ip_address_to_interface']['interface'] == test100_gi4['key']
+
+- name: "8 - Duplicate IP address on GigabitEthernet4 - test100 (with ip_address dict)"
+  networktocode.nautobot.ip_address_to_interface:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    ip_address:
+      address: "10.100.0.1/32"
+      namespace: "Global"
+    interface:
+      name: GigabitEthernet4
+      device: test100
+  register: test_eight
+
+- name: "8 - ASSERT"
+  assert:
+    that:
+      - not test_eight is changed
+      - "'already exists' in test_eight['msg']"
+      - test_eight['ip_address_to_interface']['ip_address'] == ip_address_dev['key']
+      - test_eight['ip_address_to_interface']['interface'] == test100_gi4['key']
+
+- name: "9 - Delete IP address on GigabitEthernet4 - test100 (with ip_address dict)"
+  networktocode.nautobot.ip_address_to_interface:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    ip_address:
+      address: "10.100.0.1/32"
+      namespace: "Global"
+    interface:
+      name: GigabitEthernet4
+      device: test100
+    state: absent
+  register: test_nine
+
+- name: "9 - ASSERT"
+  assert:
+    that:
+      - test_nine is changed
+      - test_nine['diff']['before']['state'] == "present"
+      - test_nine['diff']['after']['state'] == "absent"
+      - "'deleted' in test_nine['msg']"


### PR DESCRIPTION
# Closes #314
# What's Changed
## Summary
Previously, when using the `ip_address_to_interface` module, it was necessary to lookup the `key` for the IP address you wished to associate (see examples). After this change, it is possible to look it up by using a dictionary, which is more intuitive and in keeping with other Ansible modules, both in this collection and elsewhere.

It is still possible to use the older method, and there are now integration tests for both scenarios.
## Before
```
  networktocode.nautobot.ip_address_to_interface:
    url: "{{ nautobot_url }}"
    token: "{{ nautobot_token }}"
    ip_address: "{{ ip_address['key'] }}"
    interface:
      name: GigabitEthernet4
      device: test100
  vars:
    ip_address: "{{ lookup('networktocode.nautobot.lookup', 'ip-addresses', api_endpoint=nautobot_url, token=nautobot_token, api_filter='address=10.100.0.1/32') }}"
```
## After
```
  networktocode.nautobot.ip_address_to_interface:
    url: "{{ nautobot_url }}"
    token: "{{ nautobot_token }}"
    ip_address:
      address: "10.100.0.1/32"
      namespace "Global"
    interface:
      name: GigabitEthernet4
      device: test100
```
# Follow-on Work

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
