### PR TITLE
Updates the build ignore.

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -66,3 +66,5 @@ build_ignore:
   - "*.tar.gz"
   - "poetry.lock"
   - "pyproject.toml"
+  - ".venv"
+  - "venv"


### PR DESCRIPTION
Fixes #510 

Adds `.venv` and `venv` to the build ignore in the `galaxy.yml`.