### PR TITLE
Updates copyright.

### DIFF
--- a/changes/+varies.documentation
+++ b/changes/+varies.documentation
@@ -1,0 +1,1 @@
+Updated the copyright documentation footer.

--- a/docs/assets/overrides/partials/copyright.html
+++ b/docs/assets/overrides/partials/copyright.html
@@ -10,7 +10,8 @@
 
 <div class="md-copyright">
     <a href="https://squidfunk.github.io/mkdocs-material/" target="_blank" rel="noopener">Made with Material for MkDocs</a>
-    | <a href="https://www.networktocode.com/community/" target="_blank" rel="noopener">Join Nautobot Slack</a>
+    | <a href="https://www.networktocode.com/community/open-source/" target="_blank" rel="noopener">Join #Nautobot on the
+        Network to Code Slack</a>
     {% if config.extra.ntc_sponsor == true %}
     | <a href="https://networktocode.com" target="_blank" rel="noopener">Sponsored by <img
             src={{ "assets/networktocode_bw.png" | url }} class="copyright-logo"></a>


### PR DESCRIPTION
Updates the copyright footer to define NTC slack instead of Nautobot Slack.