### PR TITLE
Add VRF parameter to device_interface & vm_interface

### DIFF
--- a/changes/545.added
+++ b/changes/545.added
@@ -1,0 +1,1 @@
+Added support for the `vrf` parameter to the `device_interface` and `vm_interface` modules.

--- a/plugins/modules/device_interface.py
+++ b/plugins/modules/device_interface.py
@@ -150,7 +150,7 @@ options:
       - The VRF associated with the interface
     required: false
     type: raw
-    version_added: "CHANGEME"
+    version_added: "5.12.0"
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/device_interface.py
+++ b/plugins/modules/device_interface.py
@@ -145,6 +145,12 @@ options:
     required: false
     type: raw
     version_added: "5.4.0"
+  vrf:
+    description:
+      - The VRF associated with the interface
+    required: false
+    type: raw
+    version_added: "CHANGEME"
 """
 
 EXAMPLES = r"""
@@ -303,6 +309,7 @@ def main():
             mode=dict(required=False, type="raw"),
             untagged_vlan=dict(required=False, type="raw"),
             tagged_vlans=dict(required=False, type="raw"),
+            vrf=dict(required=False, type="raw"),
         )
     )
 

--- a/plugins/modules/vm_interface.py
+++ b/plugins/modules/vm_interface.py
@@ -96,7 +96,7 @@ options:
       - The VRF assigned to the interface
     required: false
     type: raw
-    version_added: "CHANGEME"
+    version_added: "5.12.0"
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/vm_interface.py
+++ b/plugins/modules/vm_interface.py
@@ -91,6 +91,12 @@ options:
     required: false
     type: raw
     version_added: "5.3.0"
+  vrf:
+    description:
+      - The VRF assigned to the interface
+    required: false
+    type: raw
+    version_added: "CHANGEME"
 """
 
 EXAMPLES = r"""
@@ -192,6 +198,7 @@ def main():
             untagged_vlan=dict(required=False, type="raw"),
             tagged_vlans=dict(required=False, type="raw"),
             role=dict(required=False, type="raw"),
+            vrf=dict(required=False, type="raw"),
         )
     )
 


### PR DESCRIPTION
This adds the VRF parameter to interfaces.
might help #365 (I did not find fields in the nautobot API for either devices or VMs for the assigned VRF)

Please notice the fields CHANGEME in the modules DOCUMENTATION strings for version_added param