### PR TITLE
virtual machines are now grouped by role and manufacturer

### DIFF
--- a/changes/578.fixed
+++ b/changes/578.fixed
@@ -1,0 +1,1 @@
+Virtual machines are now grouped by role and manufacturer.

--- a/changes/578.fixed
+++ b/changes/578.fixed
@@ -1,1 +1,1 @@
-Virtual machines are now grouped by role and manufacturer.
+Fixed an issue with the inventory plugin when trying to group virtual machines by role or manufacturer.

--- a/plugins/inventory/inventory.py
+++ b/plugins/inventory/inventory.py
@@ -598,7 +598,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def extract_manufacturer(self, host):
         try:
-            if host['is_virtual']:
+            if host["is_virtual"]:
                 return self._pluralize(self.manufacturers_lookup[host["platform"]["manufacturer"]["id"]])
             return self._pluralize(self.manufacturers_lookup[host["device_type"]["manufacturer"]["id"]])
         except Exception:
@@ -806,7 +806,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def refresh_device_roles_lookup(self):
         url = self.api_endpoint + "/api/extras/roles/?limit=0"
         roles = self.get_resource_list(api_url=url)
-        self.device_roles_lookup = dict((role["id"], role["name"]) for role in roles if "dcim.device" in role["content_types"] or "virtualization.virtualmachine" in role["content_types"])
+        self.device_roles_lookup = dict(
+            (role["id"], role["name"]) for role in roles if "dcim.device" in role["content_types"] or "virtualization.virtualmachine" in role["content_types"]
+        )
 
     def refresh_device_types_lookup(self):
         url = self.api_endpoint + "/api/dcim/device-types/?limit=0"

--- a/plugins/inventory/inventory.py
+++ b/plugins/inventory/inventory.py
@@ -598,6 +598,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def extract_manufacturer(self, host):
         try:
+            if host['is_virtual']:
+                return self._pluralize(self.manufacturers_lookup[host["platform"]["manufacturer"]["id"]])
             return self._pluralize(self.manufacturers_lookup[host["device_type"]["manufacturer"]["id"]])
         except Exception:
             return
@@ -804,7 +806,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def refresh_device_roles_lookup(self):
         url = self.api_endpoint + "/api/extras/roles/?limit=0"
         roles = self.get_resource_list(api_url=url)
-        self.device_roles_lookup = dict((role["id"], role["name"]) for role in roles if "dcim.device" in role["content_types"])
+        self.device_roles_lookup = dict((role["id"], role["name"]) for role in roles if "dcim.device" in role["content_types"] or "virtualization.virtualmachine" in role["content_types"])
 
     def refresh_device_types_lookup(self):
         url = self.api_endpoint + "/api/dcim/device-types/?limit=0"


### PR DESCRIPTION
# Closes: #578 

## What's Changed

Now virtual machines are grouped by role and manufacturer.  I have modified inventory.py:

- Roles can be assigned to virtualization.virtualmachine instead of dcim.devices
- Virtual machines has no device type. I use host["platform"]["manufacturer"] instead if it is a virtual machine.

## To Do
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [X] Unit, Integration Tests
- [X] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design