### PR TITLE
It should be possible to rename a device

### DIFF
--- a/changes/589.fixed
+++ b/changes/589.fixed
@@ -1,0 +1,1 @@
+It is now possible to rename a device using the UUID

--- a/plugins/module_utils/dcim.py
+++ b/plugins/module_utils/dcim.py
@@ -110,6 +110,8 @@ class NautobotDcimModule(NautobotModule):
         #     nb_endpoint.url = f"{nb_endpoint.url}/?&include=config_context_data"
 
         # Used for msg output
+        if data.get("id") and endpoint_name == "device":
+            user_query_params = {"id": data["id"]}
         if data.get("name"):
             name = data["name"]
         elif data.get("model"):

--- a/plugins/modules/device.py
+++ b/plugins/modules/device.py
@@ -293,6 +293,7 @@ def main():
     argument_spec.update(
         dict(
             name=dict(required=True, type="str"),
+            id=dict(required=False, type="str"),
             device_type=dict(required=False, type="raw"),
             role=dict(required=False, type="raw"),
             tenant=dict(required=False, type="raw"),


### PR DESCRIPTION
With this "patch" it is possible to rename a device. You can use the UUID. The name is used as new device name.

An example:

```
    - name: add device to nautobot
      networktocode.nautobot.device:
        url: "{{ nautobot_url }}"
        token: "{{ nautobot_token }}"
        name: lab
        id: 8aee10fc-9172-4fc6-8213-e64835060520
        serial: 12345
        device_type: virtual
        role: network
        location: lab
        status: Active
        state: present
```
