### PR TITLE
Changing name to optional for device module and adds id argument

### DIFF
--- a/changes/589.added
+++ b/changes/589.added
@@ -1,0 +1,1 @@
+Added the `id` parameter to the device module.

--- a/changes/589.changed
+++ b/changes/589.changed
@@ -1,0 +1,1 @@
+Changed the `name` parameter to be optional for the device module.

--- a/plugins/doc_fragments/fragments.py
+++ b/plugins/doc_fragments/fragments.py
@@ -56,6 +56,16 @@ options:
     type: str
 """
 
+    ID = r"""
+options:
+  id:
+    description:
+      - "The UUID of the object to operate on"
+    required: false
+    type: str
+    version_added: "5.13.0"
+"""
+
     TAGS = r"""
 options:
   tags:

--- a/plugins/module_utils/dcim.py
+++ b/plugins/module_utils/dcim.py
@@ -158,6 +158,10 @@ class NautobotDcimModule(NautobotModule):
                     name = f"{self.module.params['parent_module_bay'].get('parent_module')} > {name}"
             elif isinstance(self.module.params["location"], dict):
                 name = f"{self.module.params['location'].get('parent', '—')} > {self.module.params['location'].get('name')} > {name}"
+        elif data.get("id"):
+            name = data["id"]
+        elif endpoint_name == "device":
+            name = "Unnamed device"
 
         # Make color params lowercase
         if data.get("color"):

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -424,7 +424,7 @@ ALLOWED_QUERY_PARAMS = {
     "dcim.rearport": set(["name", "device", "module"]),
     "device_bay": set(["name", "device"]),
     "device_bay_template": set(["name", "device_type"]),
-    "device": set(["name"]),
+    "device": set(["name", "location", "role", "device_type", "tenant"]),
     "device_redundancy_group": set(["name"]),
     "device_type": set(["model"]),
     "dynamic_group": set(["name"]),
@@ -603,6 +603,7 @@ CONVERT_KEYS = {
 }
 
 
+# Options not sent for filtering
 NAUTOBOT_ARG_SPEC = dict(
     url=dict(type="str", required=True, fallback=(env_fallback, ["NAUTOBOT_URL"])),
     token=dict(type="str", required=True, no_log=True, fallback=(env_fallback, ["NAUTOBOT_TOKEN"])),
@@ -610,6 +611,10 @@ NAUTOBOT_ARG_SPEC = dict(
     query_params=dict(required=False, type="list", elements="str"),
     validate_certs=dict(type="raw", default=True, fallback=(env_fallback, ["NAUTOBOT_VALIDATE_CERTS"])),
     api_version=dict(type="str", required=False),
+)
+
+ID_ARG_SPEC = dict(
+    id=dict(type="str", required=False),
 )
 
 TAGS_ARG_SPEC = dict(
@@ -902,6 +907,10 @@ class NautobotModule:
         :params child(dict): This is used within `_find_ids` and passes the inner dictionary
         to build the appropriate `query_dict` for the parent
         """
+        # If they provided the ID, it's the only query param we need
+        if module_data.get("id"):
+            return {"id": module_data["id"]}
+
         # This is to change the parent key to use the proper ALLOWED_QUERY_PARAMS below for termination searches.
         if parent == "termination_a" and module_data.get("termination_a_type"):
             parent = module_data["termination_a_type"]

--- a/plugins/modules/device.py
+++ b/plugins/modules/device.py
@@ -23,24 +23,27 @@ author:
 version_added: "1.0.0"
 extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
+  - networktocode.nautobot.fragments.id
   - networktocode.nautobot.fragments.tags
   - networktocode.nautobot.fragments.custom_fields
 options:
   name:
     description:
       - The name of the device
-    required: true
+    required: false
     type: str
     version_added: "3.0.0"
   device_type:
     description:
       - Required if I(state=present) and the device does not exist yet
+      - Recommended when updating or deleting if not using I(id) or I(name) to aid with identification
     required: false
     type: raw
     version_added: "3.0.0"
   role:
     description:
       - Required if I(state=present) and the device does not exist yet
+      - Recommended when updating or deleting if not using I(id) or I(name) to aid with identification
     required: false
     type: raw
     version_added: "3.0.0"
@@ -71,6 +74,7 @@ options:
   location:
     description:
       - Required if I(state=present) and the device does not exist yet
+      - Recommended when updating or deleting if not using I(id) or I(name) to aid with identification
     required: false
     type: raw
     version_added: "3.0.0"
@@ -186,7 +190,7 @@ EXAMPLES = r"""
   gather_facts: false
 
   tasks:
-    - name: Create device within Nautobot with only required information
+    - name: Create device within Nautobot with name
       networktocode.nautobot.device:
         url: http://nautobot.local
         token: thisIsMyToken
@@ -197,24 +201,26 @@ EXAMPLES = r"""
         status: active
         state: present
 
-    - name: Create device within Nautobot with empty string name to generate UUID
-      networktocode.nautobot.device:
-        url: http://nautobot.local
-        token: thisIsMyToken
-        name: ""
-        device_type: C9410R
-        role: Core Switch
-        location:
-          name: My Location
-          parent: Parent Location
-        status: active
-        state: present
-
-    - name: Delete device within nautobot
+    - name: Delete device within nautobot with name
       networktocode.nautobot.device:
         url: http://nautobot.local
         token: thisIsMyToken
         name: Test Device
+        state: absent
+
+    - name: Rename device via ID
+      networktocode.nautobot.device:
+        url: http://nautobot.local
+        token: thisIsMyToken
+        id: 15b91de1-448d-4ff7-a00e-0a6816e8bf71
+        name: New Name
+        state: present
+
+    - name: Delete device via ID
+      networktocode.nautobot.device:
+        url: http://nautobot.local
+        token: thisIsMyToken
+        id: 15b91de1-448d-4ff7-a00e-0a6816e8bf71
         state: absent
 
     - name: Create device with tags
@@ -278,6 +284,7 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.dcim import
 )
 from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
     CUSTOM_FIELDS_ARG_SPEC,
+    ID_ARG_SPEC,
     NAUTOBOT_ARG_SPEC,
     TAGS_ARG_SPEC,
 )
@@ -288,11 +295,12 @@ def main():
     Main entry point for module execution.
     """
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
+    argument_spec.update(deepcopy(ID_ARG_SPEC))
     argument_spec.update(deepcopy(TAGS_ARG_SPEC))
     argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
-            name=dict(required=True, type="str"),
+            name=dict(required=False, type="str"),
             device_type=dict(required=False, type="raw"),
             role=dict(required=False, type="raw"),
             tenant=dict(required=False, type="raw"),

--- a/tests/integration/targets/latest/tasks/device.yml
+++ b/tests/integration/targets/latest/tasks/device.yml
@@ -336,3 +336,55 @@
       - test_nine_dot_one['diff']['after']['secrets_group'] == secrets_group_two['key']
       - test_nine_dot_one['device']['name'] == "TopSecretDevice"
       - test_nine_dot_one['msg'] == "device TopSecretDevice updated"
+
+- name: "10 - Create device without name"
+  networktocode.nautobot.device:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    device_type: "Cisco Test 2"
+    role: "Core Switch"
+    location: Parent Test Location
+    status: "Staged"
+  register: test_ten
+
+- name: "10 - ASSERT"
+  assert:
+    that:
+      - test_ten is changed
+      - test_ten['diff']['before']['state'] == 'absent'
+      - test_ten['diff']['after']['state'] == 'present'
+      - test_ten['device']['name'] == None
+      - test_ten['msg'] == "device Unnamed device created"
+
+- name: "11 - Duplicate create device without name"
+  networktocode.nautobot.device:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    device_type: "Cisco Test 2"
+    role: "Core Switch"
+    location: Parent Test Location
+    status: "Staged"
+    state: present
+  register: test_eleven
+
+- name: "11 - ASSERT"
+  assert:
+    that:
+      - not test_eleven['changed']
+      - test_eleven['msg'] == "device Unnamed device already exists"
+
+- name: "12 - Delete device by id"
+  networktocode.nautobot.device:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    id: "{{ test_ten['device']['id'] }}"
+    state: absent
+  register: test_twelve
+
+- name: "12 - ASSERT"
+  assert:
+    that:
+      - test_twelve is changed
+      - test_twelve['diff']['before']['state'] == 'present'
+      - test_twelve['diff']['after']['state'] == 'absent'
+      - "'deleted' in test_twelve['msg']"

--- a/tests/unit/module_utils/test_data/build_query_params_no_child/data.json
+++ b/tests/unit/module_utils/test_data/build_query_params_no_child/data.json
@@ -236,8 +236,7 @@
             "contact_name": "John Smith"
         },
         "expected": {
-            "id": "1",
-            "name": "Test Location"
+            "id": "1"
         }
     },
     {


### PR DESCRIPTION
Closes: #589

This PR is an enhancement to #590 to add `id` to not only the device module, but as a common inheritable argument that can be used to ultimately solve #591.