### PR TITLE
Fixes 2.2 integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ This release adds the ability to manage all objects by ID. You may now use the `
 
 - [#542](https://github.com/nautobot/nautobot-ansible/issues/542) - Replaced black and bandit with ruff.
 - [#586](https://github.com/nautobot/nautobot-ansible/issues/586) - Updated 2.4 inventory tests to account for new `module_family` field.
+- Fixed sorting of duplicate interface and service names during the inventory integration tests.
+- Fixed the `device` module integration tests to run certain tests on Nautobot 2.3+ to account for changes to the model validation.
 
 ## [v5.12.1](https://github.com/nautobot/nautobot-ansible/releases/tag/v5.12.1)
 

--- a/tests/integration/targets/latest/tasks/device.yml
+++ b/tests/integration/targets/latest/tasks/device.yml
@@ -389,9 +389,9 @@
       - test_twelve['diff']['after']['state'] == 'absent'
       - "'deleted' in test_twelve['msg']"
 
-- name: "NAUTOBOT 2.2+ DEVICE TESTS"
+- name: "NAUTOBOT 2.3+ DEVICE TESTS"
   when:
-    - "nautobot_version is version('2.2', '>=')"
+    - "nautobot_version is version('2.3', '>=')"
   block:
     - set_fact:
         device_software_version: "{{ lookup('networktocode.nautobot.lookup', 'software-versions', api_endpoint=nautobot_url, token=nautobot_token, api_filter='version=3.2.1 platform=\"Cisco IOS\"') }}"


### PR DESCRIPTION
I originally wrote the `software_version` parameter integration test for the `device` module to run on v2.2+, but it seems it is failing due to a recently deprecated model validation (https://github.com/nautobot/nautobot/issues/5494). This PR just amends the release to change the test to run on 2.3+ as it passed on those (https://github.com/nautobot/nautobot-ansible/actions/runs/16426711399).

I also updated the changelog with a few housekeeping items.