### PR TITLE
Adding `allow_unsafe` option to inventory plugins

### DIFF
--- a/changes/601.added
+++ b/changes/601.added
@@ -1,0 +1,1 @@
+Added an option to the inventory plugins to disable the wrapping of unsafe variables.

--- a/plugins/inventory/gql_inventory.py
+++ b/plugins/inventory/gql_inventory.py
@@ -87,15 +87,20 @@ options:
     elements: str
     default: []
   group_names_raw:
-      description: Will not add the group_by choice name to the group names
-      default: False
-      type: boolean
-      version_added: "4.6.0"
+    description: Will not add the group_by choice name to the group names
+    default: False
+    type: boolean
+    version_added: "4.6.0"
   page_size:
     description: Number of items to retrieve per page. Default is 0, which means all items will be retrieved.
     type: int
     default: 0
     version_added: "5.8.0"
+  allow_unsafe:
+    description:
+      - If True, allows for potentially unsafe variables to be returned as-is in the inventory.
+    default: False
+    type: boolean
 """
 
 EXAMPLES = """
@@ -285,7 +290,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             var (str): Variable value
             var_type (str): Variable type
         """
-        if check_needs_wrapping(var):
+        if self.wrap_variables and check_needs_wrapping(var):
             var = wrap_var(var)
         self.inventory.set_variable(host, var_type, var)
 
@@ -516,7 +521,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         for device in json_data["data"].get("devices", []) + json_data["data"].get("virtual_machines", []):
             hostname = device["name"]
-            if check_needs_wrapping(hostname):
+            if self.wrap_variables and check_needs_wrapping(hostname):
                 hostname = wrap_var(hostname)
             self.inventory.add_host(host=hostname)
             self.add_ip_address(device, self.default_ip_version)
@@ -562,5 +567,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self.group_names_raw = self.get_option("group_names_raw")
         self.user_cache_setting = self.get_option("cache")
         self.page_size = self.get_option("page_size")
+        self.wrap_variables = not self.get_option("allow_unsafe")
 
         self.main()

--- a/plugins/inventory/inventory.py
+++ b/plugins/inventory/inventory.py
@@ -214,6 +214,11 @@ DOCUMENTATION = """
       type: list
       elements: dict
       default: []
+    allow_unsafe:
+      description:
+        - If True, allows for potentially unsafe variables to be returned as-is in the inventory.
+      default: False
+      type: boolean
 """
 
 EXAMPLES = """
@@ -1208,7 +1213,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def set_inv_var_safely(self, hostname, variable_name, value):
         """Set inventory variable with conditional wrapping only where needed."""
-        if check_needs_wrapping(value):
+        if self.wrap_variables and check_needs_wrapping(value):
             value = wrap_var(value)
         self.inventory.set_variable(hostname, variable_name, value)
 
@@ -1374,7 +1379,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
             hostname = self.extract_name(host=host)
 
-            if check_needs_wrapping(hostname):
+            if self.wrap_variables and check_needs_wrapping(hostname):
                 hostname = wrap_var(hostname)
 
             self.inventory.add_host(host=hostname)
@@ -1435,6 +1440,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self.virtual_chassis_name = self.get_option("virtual_chassis_name")
         self.dns_name = self.get_option("dns_name")
         self.ansible_host_dns_name = self.get_option("ansible_host_dns_name")
+        self.wrap_variables = not self.get_option("allow_unsafe")
 
         # Compile regular expressions, if any
         self.rename_variables = self.parse_rename_variables(self.get_option("rename_variables"))

--- a/tests/integration/targets/inventory/files/test_2-3_gql_allow_unsafe.json
+++ b/tests/integration/targets/inventory/files/test_2-3_gql_allow_unsafe.json
@@ -1,0 +1,23 @@
+{
+    "_meta": {
+        "hostvars": {
+            "R2 {{ SEE ISSUE 114 }}": {
+                "ansible_host": "172.16.180.13",
+                "name": "R2 {{ SEE ISSUE 114 }}",
+                "primary_ip4": {
+                    "host": "172.16.180.13"
+                }
+            }
+        }
+    },
+    "all": {
+        "children": [
+            "ungrouped"
+        ]
+    },
+    "ungrouped": {
+        "hosts": [
+            "R2 {{ SEE ISSUE 114 }}"
+        ]
+    }
+}

--- a/tests/integration/targets/inventory/files/test_2-3_gql_allow_unsafe.yml
+++ b/tests/integration/targets/inventory/files/test_2-3_gql_allow_unsafe.yml
@@ -1,0 +1,13 @@
+plugin: networktocode.nautobot.gql_inventory
+api_endpoint: "http://nautobot:8000"
+token: "0123456789abcdef0123456789abcdef01234567"
+validate_certs: false
+
+query:
+  devices:
+    filters:
+      name__isw: R2
+  virtual_machines:
+    filters:
+      name: EXCLUDE ALL
+allow_unsafe: true

--- a/tests/integration/targets/inventory/files/test_2.4-3_allow_unsafe.json
+++ b/tests/integration/targets/inventory/files/test_2.4-3_allow_unsafe.json
@@ -1,0 +1,60 @@
+{
+    "_meta": {
+        "hostvars": {
+            "R2 {{ SEE ISSUE 114 }}": {
+                "ansible_host": "172.16.180.13",
+                "custom_fields": {
+                    "my_device_custom_field": null
+                },
+                "device_roles": [
+                    "Core Switch"
+                ],
+                "device_types": [
+                    "Cisco Test"
+                ],
+                "is_virtual": false,
+                "local_context_data": [
+                    {
+                        "normal_string": "this is a normal string",
+                        "string_containing_jinja2tags": "this is a string containing Jinja2 tags {{ SEE ISSUE 114 }}"
+                    }
+                ],
+                "location": "{{ SEE ISSUE 114 }}Parent Test Location 3",
+                "locations": [
+                    "{{ SEE ISSUE 114 }}Parent Test Location 3"
+                ],
+                "manufacturers": [
+                    "Cisco"
+                ],
+                "primary_ip4": "172.16.180.13",
+                "rack_groups": [
+                    "Parent3 Rack Group"
+                ],
+                "rack_role": "Test Rack Role",
+                "racks": [
+                    "Another Test Rack"
+                ],
+                "services": [],
+                "status": {
+                    "color": "4caf50",
+                    "custom_fields": {},
+                    "description": "Unit is active",
+                    "display": "Active",
+                    "name": "Active",
+                    "object_type": "extras.status"
+                },
+                "tags": []
+            }
+        }
+    },
+    "all": {
+        "children": [
+            "ungrouped"
+        ]
+    },
+    "ungrouped": {
+        "hosts": [
+            "R2 {{ SEE ISSUE 114 }}"
+        ]
+    }
+}

--- a/tests/integration/targets/inventory/files/test_2.4-3_allow_unsafe.yml
+++ b/tests/integration/targets/inventory/files/test_2.4-3_allow_unsafe.yml
@@ -1,0 +1,8 @@
+plugin: networktocode.nautobot.inventory
+api_endpoint: "http://nautobot:8000"
+token: "0123456789abcdef0123456789abcdef01234567"
+validate_certs: false
+
+query_filters:
+  - name__isw: R2
+allow_unsafe: true

--- a/tests/unit/inventory/test_graphql.py
+++ b/tests/unit/inventory/test_graphql.py
@@ -47,6 +47,7 @@ def inventory_fixture():
     inventory.inventory = InventoryData()
     inventory.inventory.add_host("mydevice")
     inventory.group_names_raw = False
+    inventory.wrap_variables = True
 
     return inventory
 

--- a/tests/unit/inventory/test_nb_inventory.py
+++ b/tests/unit/inventory/test_nb_inventory.py
@@ -51,6 +51,7 @@ def inventory_fixture(allowed_device_query_parameters_fixture, allowed_vm_query_
     inventory.allowed_vm_query_parameters = allowed_vm_query_parameters_fixture
     # Inventory mock, to validate what has been set via inventory.inventory.set_variable
     inventory.inventory = MockInventory()
+    inventory.wrap_variables = True
 
     return inventory
 


### PR DESCRIPTION
Closes: #601

This PR adds the `allow_unsafe` option to both inventory plugins. It essentially allows the end user to disable the function that was added in #543.

