### PR TITLE
Adding missing custom_fields and tags support

### DIFF
--- a/changes/627.added
+++ b/changes/627.added
@@ -1,0 +1,2 @@
+Added `custom_fields` option to multiple modules that support it yet were missing it.
+Added `tags` option to multiple modules that support it yet were missing it.

--- a/plugins/modules/circuit_termination.py
+++ b/plugins/modules/circuit_termination.py
@@ -22,6 +22,8 @@ version_added: "1.0.0"
 extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
+  - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
   circuit:
     description:
@@ -166,7 +168,12 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.circuits im
     NB_CIRCUIT_TERMINATIONS,
     NautobotCircuitsModule,
 )
-from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import ID_ARG_SPEC, NAUTOBOT_ARG_SPEC
+from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
+    ID_ARG_SPEC,
+    NAUTOBOT_ARG_SPEC,
+    TAGS_ARG_SPEC,
+)
 
 
 def main():
@@ -175,6 +182,8 @@ def main():
     """
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
+    argument_spec.update(deepcopy(TAGS_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             circuit=dict(required=False, type="raw"),

--- a/plugins/modules/circuit_type.py
+++ b/plugins/modules/circuit_type.py
@@ -22,6 +22,7 @@ version_added: "1.0.0"
 extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
+  - networktocode.nautobot.fragments.custom_fields
 options:
   name:
     description:
@@ -85,7 +86,11 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.circuits im
     NB_CIRCUIT_TYPES,
     NautobotCircuitsModule,
 )
-from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import ID_ARG_SPEC, NAUTOBOT_ARG_SPEC
+from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
+    ID_ARG_SPEC,
+    NAUTOBOT_ARG_SPEC,
+)
 
 
 def main():
@@ -94,6 +99,7 @@ def main():
     """
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             name=dict(required=False, type="str"),

--- a/plugins/modules/cluster_group.py
+++ b/plugins/modules/cluster_group.py
@@ -22,6 +22,7 @@ version_added: "1.0.0"
 extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
+  - networktocode.nautobot.fragments.custom_fields
 options:
   name:
     description:
@@ -81,7 +82,11 @@ msg:
 from copy import deepcopy
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import ID_ARG_SPEC, NAUTOBOT_ARG_SPEC
+from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
+    ID_ARG_SPEC,
+    NAUTOBOT_ARG_SPEC,
+)
 from ansible_collections.networktocode.nautobot.plugins.module_utils.virtualization import (
     NB_CLUSTER_GROUP,
     NautobotVirtualizationModule,
@@ -94,6 +99,7 @@ def main():
     """
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             name=dict(required=False, type="str"),

--- a/plugins/modules/cluster_type.py
+++ b/plugins/modules/cluster_type.py
@@ -22,6 +22,7 @@ version_added: "1.0.0"
 extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
+  - networktocode.nautobot.fragments.custom_fields
 options:
   name:
     description:
@@ -81,7 +82,11 @@ msg:
 from copy import deepcopy
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import ID_ARG_SPEC, NAUTOBOT_ARG_SPEC
+from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
+    ID_ARG_SPEC,
+    NAUTOBOT_ARG_SPEC,
+)
 from ansible_collections.networktocode.nautobot.plugins.module_utils.virtualization import (
     NB_CLUSTER_TYPE,
     NautobotVirtualizationModule,
@@ -94,6 +99,7 @@ def main():
     """
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             name=dict(required=False, type="str"),

--- a/plugins/modules/console_port.py
+++ b/plugins/modules/console_port.py
@@ -24,6 +24,7 @@ extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
   - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
   device:
     description:
@@ -128,6 +129,7 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.dcim import
     NautobotDcimModule,
 )
 from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
     ID_ARG_SPEC,
     NAUTOBOT_ARG_SPEC,
     TAGS_ARG_SPEC,
@@ -141,6 +143,7 @@ def main():
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
     argument_spec.update(deepcopy(TAGS_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             device=dict(required=False, type="raw"),

--- a/plugins/modules/console_port_template.py
+++ b/plugins/modules/console_port_template.py
@@ -23,6 +23,7 @@ version_added: "1.0.0"
 extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
+  - networktocode.nautobot.fragments.custom_fields
 options:
   device_type:
     description:
@@ -111,7 +112,11 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.dcim import
     NB_CONSOLE_PORT_TEMPLATES,
     NautobotDcimModule,
 )
-from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import ID_ARG_SPEC, NAUTOBOT_ARG_SPEC
+from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
+    ID_ARG_SPEC,
+    NAUTOBOT_ARG_SPEC,
+)
 
 
 def main():
@@ -120,6 +125,7 @@ def main():
     """
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             device_type=dict(required=False, type="raw"),

--- a/plugins/modules/console_server_port.py
+++ b/plugins/modules/console_server_port.py
@@ -24,6 +24,7 @@ extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
   - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
   device:
     description:
@@ -128,6 +129,7 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.dcim import
     NautobotDcimModule,
 )
 from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
     ID_ARG_SPEC,
     NAUTOBOT_ARG_SPEC,
     TAGS_ARG_SPEC,
@@ -141,6 +143,7 @@ def main():
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
     argument_spec.update(deepcopy(TAGS_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             device=dict(required=False, type="raw"),

--- a/plugins/modules/console_server_port_template.py
+++ b/plugins/modules/console_server_port_template.py
@@ -23,6 +23,7 @@ version_added: "1.0.0"
 extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
+  - networktocode.nautobot.fragments.custom_fields
 options:
   device_type:
     description:
@@ -111,7 +112,11 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.dcim import
     NB_CONSOLE_SERVER_PORT_TEMPLATES,
     NautobotDcimModule,
 )
-from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import ID_ARG_SPEC, NAUTOBOT_ARG_SPEC
+from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
+    ID_ARG_SPEC,
+    NAUTOBOT_ARG_SPEC,
+)
 
 
 def main():
@@ -120,6 +125,7 @@ def main():
     """
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             device_type=dict(required=False, type="raw"),

--- a/plugins/modules/device_bay.py
+++ b/plugins/modules/device_bay.py
@@ -23,6 +23,7 @@ extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
   - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
   device:
     description:
@@ -110,6 +111,7 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.dcim import
     NautobotDcimModule,
 )
 from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
     ID_ARG_SPEC,
     NAUTOBOT_ARG_SPEC,
     TAGS_ARG_SPEC,
@@ -123,6 +125,7 @@ def main():
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
     argument_spec.update(deepcopy(TAGS_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             device=dict(required=False, type="raw"),

--- a/plugins/modules/device_bay_template.py
+++ b/plugins/modules/device_bay_template.py
@@ -23,6 +23,7 @@ version_added: "1.0.0"
 extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
+  - networktocode.nautobot.fragments.custom_fields
 options:
   device_type:
     description:
@@ -89,7 +90,11 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.dcim import
     NB_DEVICE_BAY_TEMPLATES,
     NautobotDcimModule,
 )
-from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import ID_ARG_SPEC, NAUTOBOT_ARG_SPEC
+from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
+    ID_ARG_SPEC,
+    NAUTOBOT_ARG_SPEC,
+)
 
 
 def main():
@@ -98,6 +103,7 @@ def main():
     """
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             device_type=dict(required=False, type="raw"),

--- a/plugins/modules/device_interface_template.py
+++ b/plugins/modules/device_interface_template.py
@@ -23,6 +23,7 @@ version_added: "1.0.0"
 extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
+  - networktocode.nautobot.fragments.custom_fields
 options:
   device_type:
     description:
@@ -124,7 +125,11 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.dcim import
     NB_INTERFACE_TEMPLATES,
     NautobotDcimModule,
 )
-from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import ID_ARG_SPEC, NAUTOBOT_ARG_SPEC
+from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
+    ID_ARG_SPEC,
+    NAUTOBOT_ARG_SPEC,
+)
 
 
 def main():
@@ -133,6 +138,7 @@ def main():
     """
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             device_type=dict(required=False, type="raw"),

--- a/plugins/modules/front_port.py
+++ b/plugins/modules/front_port.py
@@ -24,6 +24,7 @@ extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
   - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
   device:
     description:
@@ -150,6 +151,7 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.dcim import
     NautobotDcimModule,
 )
 from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
     ID_ARG_SPEC,
     NAUTOBOT_ARG_SPEC,
     TAGS_ARG_SPEC,
@@ -163,6 +165,7 @@ def main():
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
     argument_spec.update(deepcopy(TAGS_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             device=dict(required=False, type="raw"),

--- a/plugins/modules/front_port_template.py
+++ b/plugins/modules/front_port_template.py
@@ -23,6 +23,7 @@ version_added: "1.0.0"
 extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
+  - networktocode.nautobot.fragments.custom_fields
 options:
   device_type:
     description:
@@ -132,6 +133,7 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.dcim import
     NautobotDcimModule,
 )
 from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
     ID_ARG_SPEC,
     NAUTOBOT_ARG_SPEC,
 )
@@ -143,6 +145,7 @@ def main():
     """
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             device_type=dict(required=False, type="raw"),

--- a/plugins/modules/manufacturer.py
+++ b/plugins/modules/manufacturer.py
@@ -22,6 +22,7 @@ version_added: "1.0.0"
 extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
+  - networktocode.nautobot.fragments.custom_fields
 options:
   name:
     description:
@@ -87,6 +88,7 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.dcim import
     NautobotDcimModule,
 )
 from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
     ID_ARG_SPEC,
     NAUTOBOT_ARG_SPEC,
 )
@@ -98,6 +100,7 @@ def main():
     """
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             name=dict(required=False, type="str"),

--- a/plugins/modules/metadata_type.py
+++ b/plugins/modules/metadata_type.py
@@ -21,6 +21,7 @@ version_added: "5.5.0"
 extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
+  - networktocode.nautobot.fragments.tags
   - networktocode.nautobot.fragments.custom_fields
 options:
   name:
@@ -111,6 +112,7 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.utils impor
     CUSTOM_FIELDS_ARG_SPEC,
     ID_ARG_SPEC,
     NAUTOBOT_ARG_SPEC,
+    TAGS_ARG_SPEC,
 )
 
 
@@ -120,6 +122,7 @@ def main():
     """
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
+    argument_spec.update(deepcopy(TAGS_ARG_SPEC))
     argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(

--- a/plugins/modules/platform.py
+++ b/plugins/modules/platform.py
@@ -22,6 +22,7 @@ version_added: "1.0.0"
 extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
+  - networktocode.nautobot.fragments.custom_fields
 options:
   name:
     description:
@@ -123,6 +124,7 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.dcim import
     NautobotDcimModule,
 )
 from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
     ID_ARG_SPEC,
     NAUTOBOT_ARG_SPEC,
 )
@@ -134,6 +136,7 @@ def main():
     """
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             name=dict(required=False, type="str"),

--- a/plugins/modules/power_outlet.py
+++ b/plugins/modules/power_outlet.py
@@ -24,6 +24,7 @@ extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
   - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
   device:
     description:
@@ -138,6 +139,7 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.dcim import
     NautobotDcimModule,
 )
 from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
     ID_ARG_SPEC,
     NAUTOBOT_ARG_SPEC,
     TAGS_ARG_SPEC,
@@ -151,6 +153,7 @@ def main():
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
     argument_spec.update(deepcopy(TAGS_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             device=dict(required=False, type="raw"),

--- a/plugins/modules/power_outlet_template.py
+++ b/plugins/modules/power_outlet_template.py
@@ -23,6 +23,7 @@ version_added: "1.0.0"
 extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
+  - networktocode.nautobot.fragments.custom_fields
 options:
   device_type:
     description:
@@ -130,6 +131,7 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.dcim import
     NautobotDcimModule,
 )
 from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
     ID_ARG_SPEC,
     NAUTOBOT_ARG_SPEC,
 )
@@ -141,6 +143,7 @@ def main():
     """
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             device_type=dict(required=False, type="raw"),

--- a/plugins/modules/power_panel.py
+++ b/plugins/modules/power_panel.py
@@ -23,6 +23,8 @@ version_added: "1.0.0"
 extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
+  - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
   location:
     description:
@@ -109,8 +111,10 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.dcim import
     NautobotDcimModule,
 )
 from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
     ID_ARG_SPEC,
     NAUTOBOT_ARG_SPEC,
+    TAGS_ARG_SPEC,
 )
 
 
@@ -120,6 +124,8 @@ def main():
     """
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
+    argument_spec.update(deepcopy(TAGS_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             location=dict(required=False, type="raw"),

--- a/plugins/modules/power_port.py
+++ b/plugins/modules/power_port.py
@@ -24,6 +24,7 @@ extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
   - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
   device:
     description:
@@ -134,6 +135,7 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.dcim import
     NautobotDcimModule,
 )
 from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
     ID_ARG_SPEC,
     NAUTOBOT_ARG_SPEC,
     TAGS_ARG_SPEC,
@@ -147,6 +149,7 @@ def main():
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
     argument_spec.update(deepcopy(TAGS_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             device=dict(required=False, type="raw"),

--- a/plugins/modules/power_port_template.py
+++ b/plugins/modules/power_port_template.py
@@ -23,6 +23,7 @@ version_added: "1.0.0"
 extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
+  - networktocode.nautobot.fragments.custom_fields
 options:
   device_type:
     description:
@@ -126,6 +127,7 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.dcim import
     NautobotDcimModule,
 )
 from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
     ID_ARG_SPEC,
     NAUTOBOT_ARG_SPEC,
 )
@@ -137,6 +139,7 @@ def main():
     """
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             device_type=dict(required=False, type="raw"),

--- a/plugins/modules/rack_group.py
+++ b/plugins/modules/rack_group.py
@@ -22,6 +22,7 @@ version_added: "1.0.0"
 extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
+  - networktocode.nautobot.fragments.custom_fields
 options:
   description:
     description:
@@ -105,6 +106,7 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.dcim import
     NautobotDcimModule,
 )
 from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
     ID_ARG_SPEC,
     NAUTOBOT_ARG_SPEC,
 )
@@ -116,6 +118,7 @@ def main():
     """
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             name=dict(required=False, type="str"),

--- a/plugins/modules/rear_port.py
+++ b/plugins/modules/rear_port.py
@@ -24,6 +24,7 @@ extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
   - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
   device:
     description:
@@ -139,6 +140,7 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.dcim import
     NautobotDcimModule,
 )
 from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
     ID_ARG_SPEC,
     NAUTOBOT_ARG_SPEC,
     TAGS_ARG_SPEC,
@@ -152,6 +154,7 @@ def main():
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
     argument_spec.update(deepcopy(TAGS_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             device=dict(required=False, type="raw"),

--- a/plugins/modules/rear_port_template.py
+++ b/plugins/modules/rear_port_template.py
@@ -23,6 +23,7 @@ version_added: "1.0.0"
 extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
+  - networktocode.nautobot.fragments.custom_fields
 options:
   device_type:
     description:
@@ -122,6 +123,7 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.dcim import
     NautobotDcimModule,
 )
 from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
     ID_ARG_SPEC,
     NAUTOBOT_ARG_SPEC,
 )
@@ -133,6 +135,7 @@ def main():
     """
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             device_type=dict(required=False, type="raw"),

--- a/plugins/modules/rir.py
+++ b/plugins/modules/rir.py
@@ -22,6 +22,7 @@ version_added: "1.0.0"
 extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
+  - networktocode.nautobot.fragments.custom_fields
 options:
   name:
     description:
@@ -94,6 +95,7 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.ipam import
     NautobotIpamModule,
 )
 from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
     ID_ARG_SPEC,
     NAUTOBOT_ARG_SPEC,
 )
@@ -105,6 +107,7 @@ def main():
     """
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             name=dict(required=False, type="str"),

--- a/plugins/modules/status.py
+++ b/plugins/modules/status.py
@@ -23,6 +23,7 @@ version_added: "1.0.0"
 extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
+  - networktocode.nautobot.fragments.custom_fields
 options:
   name:
     description:
@@ -111,6 +112,7 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.extras impo
     NautobotExtrasModule,
 )
 from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
     ID_ARG_SPEC,
     NAUTOBOT_ARG_SPEC,
 )
@@ -122,6 +124,7 @@ def main():
     """
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             name=dict(required=False, type="str"),

--- a/plugins/modules/tenant_group.py
+++ b/plugins/modules/tenant_group.py
@@ -22,6 +22,7 @@ version_added: "1.0.0"
 extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
+  - networktocode.nautobot.fragments.custom_fields
 options:
   name:
     description:
@@ -101,6 +102,7 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.tenancy imp
     NautobotTenancyModule,
 )
 from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
     ID_ARG_SPEC,
     NAUTOBOT_ARG_SPEC,
 )
@@ -112,6 +114,7 @@ def main():
     """
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             name=dict(required=False, type="str"),

--- a/plugins/modules/virtual_chassis.py
+++ b/plugins/modules/virtual_chassis.py
@@ -24,6 +24,7 @@ extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
   - networktocode.nautobot.fragments.tags
+  - networktocode.nautobot.fragments.custom_fields
 options:
   name:
     description:
@@ -103,6 +104,7 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.dcim import
     NautobotDcimModule,
 )
 from ansible_collections.networktocode.nautobot.plugins.module_utils.utils import (
+    CUSTOM_FIELDS_ARG_SPEC,
     ID_ARG_SPEC,
     NAUTOBOT_ARG_SPEC,
     TAGS_ARG_SPEC,
@@ -116,6 +118,7 @@ def main():
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
     argument_spec.update(deepcopy(TAGS_ARG_SPEC))
+    argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(
             name=dict(required=False, type="str"),

--- a/plugins/modules/vlan_group.py
+++ b/plugins/modules/vlan_group.py
@@ -22,6 +22,7 @@ version_added: "1.0.0"
 extends_documentation_fragment:
   - networktocode.nautobot.fragments.base
   - networktocode.nautobot.fragments.id
+  - networktocode.nautobot.fragments.tags
   - networktocode.nautobot.fragments.custom_fields
 options:
   name:
@@ -99,6 +100,7 @@ from ansible_collections.networktocode.nautobot.plugins.module_utils.utils impor
     CUSTOM_FIELDS_ARG_SPEC,
     ID_ARG_SPEC,
     NAUTOBOT_ARG_SPEC,
+    TAGS_ARG_SPEC,
 )
 
 
@@ -108,6 +110,7 @@ def main():
     """
     argument_spec = deepcopy(NAUTOBOT_ARG_SPEC)
     argument_spec.update(deepcopy(ID_ARG_SPEC))
+    argument_spec.update(deepcopy(TAGS_ARG_SPEC))
     argument_spec.update(deepcopy(CUSTOM_FIELDS_ARG_SPEC))
     argument_spec.update(
         dict(


### PR DESCRIPTION
Closes: #627 

<details>
    <summary>Custom Field Audit</summary>

# Models that support custom fields:

```
circuits.circuit
circuits.circuittermination
circuits.circuittype
circuits.provider
circuits.providernetwork
cloud.cloudaccount
cloud.cloudnetwork
cloud.cloudresourcetype
cloud.cloudservice
dcim.cable
dcim.consoleport
dcim.consoleporttemplate
dcim.consoleserverport
dcim.consoleserverporttemplate
dcim.controller
dcim.controllermanageddevicegroup
dcim.device
dcim.devicebay
dcim.devicebaytemplate
dcim.devicefamily
dcim.deviceredundancygroup
dcim.devicetype
dcim.frontport
dcim.frontporttemplate
dcim.interface
dcim.interfaceredundancygroup
dcim.interfacetemplate
dcim.inventoryitem
dcim.location
dcim.locationtype
dcim.manufacturer
dcim.module
dcim.modulebay
dcim.modulebaytemplate
dcim.modulefamily
dcim.moduletype
dcim.platform
dcim.powerfeed
dcim.poweroutlet
dcim.poweroutlettemplate
dcim.powerpanel
dcim.powerport
dcim.powerporttemplate
dcim.rack
dcim.rackgroup
dcim.rackreservation
dcim.rearport
dcim.rearporttemplate
dcim.softwareimagefile
dcim.softwareversion
dcim.virtualchassis
dcim.virtualdevicecontext
extras.configcontextschema
extras.contact
extras.contactassociation
extras.dynamicgroup
extras.externalintegration
extras.gitrepository
extras.job
extras.jobhook
extras.jobqueue
extras.jobresult
extras.metadatatype
extras.role
extras.secret
extras.secretsgroup
extras.staticgroupassociation
extras.status
extras.tag
extras.team
ipam.ipaddress
ipam.namespace
ipam.prefix
ipam.rir
ipam.routetarget
ipam.service
ipam.vlan
ipam.vlangroup
ipam.vrf
tenancy.tenant
tenancy.tenantgroup
virtualization.cluster
virtualization.clustergroup
virtualization.clustertype
virtualization.virtualmachine
virtualization.vminterface
wireless.radioprofile
wireless.supporteddatarate
wireless.wirelessnetwork
```

# Existing modules without custom field support (should be no overlap now):

```
plugins/modules/admin_group.py
plugins/modules/admin_permission.py
plugins/modules/admin_user.py
plugins/modules/cloud_network_prefix_assignment.py
plugins/modules/cloud_service_network_assignment.py
plugins/modules/custom_field_choice.py
plugins/modules/custom_field.py
plugins/modules/ip_address_to_interface.py
plugins/modules/job_button.py
plugins/modules/metadata_choice.py
plugins/modules/object_metadata.py
plugins/modules/plugin.py
plugins/modules/prefix_location.py
plugins/modules/relationship_association.py
plugins/modules/secrets_groups_association.py
plugins/modules/vlan_location.py
plugins/modules/vrf_device_assignment.py
```

</details>

<details>
    <summary>Tag Audit</summary>

# Models that support tags:

```
circuits.circuit
circuits.circuittermination
circuits.provider
circuits.providernetwork
cloud.cloudaccount
cloud.cloudnetwork
cloud.cloudresourcetype
cloud.cloudservice
dcim.cable
dcim.consoleport
dcim.consoleserverport
dcim.controller
dcim.controllermanageddevicegroup
dcim.device
dcim.devicebay
dcim.devicefamily
dcim.deviceredundancygroup
dcim.devicetype
dcim.frontport
dcim.interface
dcim.interfaceredundancygroup
dcim.inventoryitem
dcim.location
dcim.module
dcim.modulebay
dcim.modulefamily
dcim.moduletype
dcim.powerfeed
dcim.poweroutlet
dcim.powerpanel
dcim.powerport
dcim.rack
dcim.rackreservation
dcim.rearport
dcim.softwareimagefile
dcim.softwareversion
dcim.virtualchassis
dcim.virtualdevicecontext
extras.contact
extras.dynamicgroup
extras.externalintegration
extras.gitrepository
extras.job
extras.jobqueue
extras.metadatatype
extras.secret
extras.team
ipam.ipaddress
ipam.namespace
ipam.prefix
ipam.routetarget
ipam.service
ipam.vlan
ipam.vlangroup
ipam.vrf
tenancy.tenant
virtualization.cluster
virtualization.virtualmachine
virtualization.vminterface
wireless.radioprofile
wireless.supporteddatarate
wireless.wirelessnetwork
```

# Existing modules without tag support (should be no overlap now):

```
plugins/modules/admin_group.py
plugins/modules/admin_permission.py
plugins/modules/admin_user.py
plugins/modules/circuit_type.py
plugins/modules/cloud_network_prefix_assignment.py
plugins/modules/cloud_service_network_assignment.py
plugins/modules/cluster_group.py
plugins/modules/cluster_type.py
plugins/modules/console_port_template.py
plugins/modules/console_server_port_template.py
plugins/modules/custom_field_choice.py
plugins/modules/custom_field.py
plugins/modules/device_bay_template.py
plugins/modules/device_interface_template.py
plugins/modules/front_port_template.py
plugins/modules/ip_address_to_interface.py
plugins/modules/job_button.py
plugins/modules/location_type.py
plugins/modules/manufacturer.py
plugins/modules/metadata_choice.py
plugins/modules/object_metadata.py
plugins/modules/platform.py
plugins/modules/plugin.py
plugins/modules/power_outlet_template.py
plugins/modules/power_port_template.py
plugins/modules/prefix_location.py
plugins/modules/rack_group.py
plugins/modules/rear_port_template.py
plugins/modules/relationship_association.py
plugins/modules/rir.py
plugins/modules/role.py
plugins/modules/secrets_group.py
plugins/modules/secrets_groups_association.py
plugins/modules/static_group_association.py
plugins/modules/status.py
plugins/modules/tag.py
plugins/modules/tenant_group.py
plugins/modules/vlan_location.py
plugins/modules/vrf_device_assignment.py
```

</details>
