### PR TITLE
Fix EDA link in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,13 @@ Here is a list of available modules along with a brief description of each:
 - **networktocode.nautobot.rack_group**: Manage rack groups in Nautobot.
 - **networktocode.nautobot.inventory_item**: Manage inventory items in Nautobot.
 
-### Event Driven Ansible (EDA)
+### Event-Driven Ansible (EDA)
 
 This collection comes with a EDA source plugin that can monitor the Nautobot Change Log based on a configurable interval.
 
 - **networktocode.nautobot.nautobot_changelog**: Listen for Change Log events and trigger actions against those.
 
-More information on the Nautobot source plugin and EDA can be found [here](./extensions/eda/plugins/event_source/README.md).
+More information on the Nautobot source plugin and EDA can be found [here](getting_started/how-to-use/eda.md).
 
 
 ### Releasing, Versioning, and Deprecation

--- a/changes/514.documentation
+++ b/changes/514.documentation
@@ -1,0 +1,1 @@
+Fixed broken EDA link in docs.

--- a/docs/getting_started/how-to-use/eda.md
+++ b/docs/getting_started/how-to-use/eda.md
@@ -1,6 +1,6 @@
 # EDA Event Source Plugin
 
-For more information on [Event Driven Ansible](https://ansible.readthedocs.io/projects/ansible-eda/).
+More information on Event-Driven Ansible is available at the [Ansible community documentation](https://ansible.readthedocs.io/projects/ansible-eda/).
 
 Event source plugins describe the source of an event stream. For the Nautobot Change log source plugin, the plugin will query the log based on a configured interval. Five seconds by default.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,7 @@ nav:
       - Modules: "getting_started/how-to-use/modules.md"
       - Inventory: "getting_started/how-to-use/inventory.md"
       - Advanced Usage - Modules: "getting_started/how-to-use/advanced.md"
+      - EDA Event Source Plugin: "getting_started/how-to-use/eda.md"
     - Contributing: 
       - "getting_started/index.md"
       - Modules:


### PR DESCRIPTION
Resolves a broken documentation link from the main Ansible docs to the Event-Driven Ansible (EDA) Event Source plugin README. The README was located outside the `./docs/` path, which MkDocs could not include.

Changes:

Moved `extensions/eda/plugins/event_source/README.md` content to `docs/eda.md`.

Updated references to the README in the documentation to point to the new location.

Also, hyphenated references to Event-Driven Ansible to match Red Hat.