### PR TITLE
Adding performance improvements to the inventory plugin

### DIFF
--- a/changes/642.added
+++ b/changes/642.added
@@ -1,0 +1,1 @@
+Added a local file cache of the OpenAPI spec of Nautobot for the inventory plugin when using query filters.

--- a/changes/642.changed
+++ b/changes/642.changed
@@ -1,0 +1,1 @@
+Changed the inventory plugin to not fetch the OpenAPI spec if the user does not provide any query filters.


### PR DESCRIPTION
Closes: #642

This PR accomplishes the following:
- It skips the fetch of the OpenAPI spec if the user is not providing any query filters that need to be validated
- It adds a local file cache of the OpenAPI spec so that it does not need to fetch it every time