### PR TITLE
Add Code of Conduct link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Testing is completed via the GitHub actions located in the `.github/workflows` d
 
 Check out the docs at https://docs.nautobot.com/projects/ansible/en/stable/getting_started/
 
+## Code of Conduct
+
+This project adheres to the [Network to Code Code of Conduct](CODE_OF_CONDUCT). By participating, you are expected to uphold this code.
+
 ## Support
 
 For issues please use [GitHub Issues](https://github.com/nautobot/nautobot-ansible) to open any issue that you may have. Additional community is available at the [Network to Code Slack](https://networktocode.slack.com) and [sign up](https://slack.networktocode.com).

--- a/changes/694.documentation
+++ b/changes/694.documentation
@@ -1,0 +1,1 @@
+Added Code of Conduct link to README for Ansible inclusion compliance.


### PR DESCRIPTION
## Summary
Adds a Code of Conduct section to README.md linking to the existing CODE_OF_CONDUCT file.

## Closes
Closes #694

## Context
This is required for Ansible inclusion per the [Collection Infrastructure Requirements](https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html#collection-infrastructure):

> The CoC MUST be linked from the README.md file, or MUST be present or linked from the CODE_OF_CONDUCT.md file in the collection root.

## Changes
- Added "Code of Conduct" section to README.md after "Contributing" section
- Links to existing CODE_OF_CONDUCT file