### PR TITLE
Add CONTRIBUTING.md linking to documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Thank you for your interest in contributing to Nautobot Ansible!
+
+Please see the main contributing guide here:
+
+https://docs.nautobot.com/projects/ansible/en/stable/getting_started/
+
+That guide covers contributing guidelines, MkDocs documentation workflow, changelog fragments, and the release process. This file is intentionally brief and simply redirects to the authoritative docs.

--- a/changes/695.documentation
+++ b/changes/695.documentation
@@ -1,0 +1,1 @@
+Add CONTRIBUTING.md that links to the official documentation.


### PR DESCRIPTION
## Summary
Adds a CONTRIBUTING.md file that redirects to the existing contributing documentation.

## Closes
Closes #695

## Context
For Ansible inclusion, collections SHOULD have contributor guidelines in CONTRIBUTING.md or README.md. Rather than duplicating content, this file redirects to the authoritative docs.

## Changes
- Added `CONTRIBUTING.md` pointing to https://docs.nautobot.com/projects/ansible/en/stable/getting_started/
- Added towncrier changelog fragment