### PR TITLE
docs: Update Python and Ansible version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Full documentation for this App can be found over on the [Nautobot Docs](https:/
 ## Requirements
 
 - Nautobot 1.0.0+ or the two latest Nautobot releases
-- Python 3.6+
+- Python 3.11+ (aligned with ansible-core 2.18+ support)
 - Python modules: **pynautobot 2.x+**
-- Ansible 2.9+
+- Ansible 2.18+
 - Nautobot write-enabled token when using `modules` or read-only token for `lookup/inventory`
 
 ## Installation

--- a/changes/697.documentation
+++ b/changes/697.documentation
@@ -1,0 +1,1 @@
+Updated Python and Ansible version requirements in README to reflect actual supported versions.


### PR DESCRIPTION
## Closes #697

### Changes
- Python 3.6+ → **Python 3.11+** (aligned with ansible-core 2.18+ support)
- Ansible 2.9+ → **Ansible 2.18+**

### Why
README was outdated. CI tests Python 3.11/3.12/3.13 and `meta/runtime.yml` requires ansible >= 2.18.0.

Related to #363 (Ansible Inclusion)