### PR TITLE
feat: Add meta/execution-environment.yml for Ansible Builder

### DIFF
--- a/changes/696.added
+++ b/changes/696.added
@@ -1,0 +1,1 @@
+Added meta/execution-environment.yml for Ansible Builder support.

--- a/meta/execution-environment.yml
+++ b/meta/execution-environment.yml
@@ -1,0 +1,4 @@
+---
+version: 1
+dependencies:
+  python: requirements.txt

--- a/meta/execution-environment.yml
+++ b/meta/execution-environment.yml
@@ -1,4 +1,4 @@
 ---
 version: 1
 dependencies:
-  python: requirements.txt
+  python: meta/requirements.txt

--- a/meta/requirements.txt
+++ b/meta/requirements.txt
@@ -1,0 +1,1 @@
+pynautobot


### PR DESCRIPTION
## Closes #696

### Changes
Adds two new files to `meta/`:
- `execution-environment.yml` - Ansible Builder configuration
- `requirements.txt` - Python dependencies (pynautobot)

### Why
Ansible inclusion requirements recommend listing controller-side Python package requirements in `meta/execution-environment.yml` for use with [Ansible Builder](https://ansible-builder.readthedocs.io/) and Execution Environments.

Related to #363 (Ansible Inclusion)