### PR TITLE
Add missing RETURN block to service module and documentation tests

### DIFF
--- a/changes/709.documentation
+++ b/changes/709.documentation
@@ -1,0 +1,1 @@
+Added missing RETURN block to the service module and added unit tests to validate all modules have required Ansible documentation blocks (DOCUMENTATION, EXAMPLES, RETURN, version_added).

--- a/changes/709.documentation
+++ b/changes/709.documentation
@@ -1,1 +1,1 @@
-Added missing RETURN block to the service module and added unit tests to validate all modules have required Ansible documentation blocks (DOCUMENTATION, EXAMPLES, RETURN, version_added).
+Added missing RETURN block to the service module.

--- a/changes/709.housekeeping
+++ b/changes/709.housekeeping
@@ -1,0 +1,1 @@
+Added unit tests to validate all modules have required Ansible documentation blocks (DOCUMENTATION, EXAMPLES, RETURN, version_added).

--- a/plugins/modules/service.py
+++ b/plugins/modules/service.py
@@ -104,6 +104,17 @@ EXAMPLES = r"""
     state: absent
 """
 
+RETURN = r"""
+services:
+  description: Serialized object as created or already existent within Nautobot
+  returned: success (when I(state=present))
+  type: dict
+msg:
+  description: Message indicating failure or info about what has been achieved
+  returned: always
+  type: str
+"""
+
 from copy import deepcopy
 
 from ansible.module_utils.basic import AnsibleModule

--- a/tests/unit/modules/test_module_documentation.py
+++ b/tests/unit/modules/test_module_documentation.py
@@ -1,0 +1,62 @@
+"""Tests to validate all modules have required Ansible documentation blocks.
+
+Per the Ansible collection requirements:
+https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html#documentation-requirements
+
+All modules and plugins:
+- MUST include a DOCUMENTATION block.
+- MUST include an EXAMPLES block (except where not relevant for the plugin type).
+- MUST include a RETURN block for modules and other plugins that return data.
+"""
+
+import os
+
+import pytest
+
+MODULES_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "..", "plugins", "modules")
+MODULES_PATH = os.path.normpath(MODULES_PATH)
+
+
+def get_module_files():
+    """Return a list of all Python module files (excluding __init__.py)."""
+    module_files = []
+    for filename in sorted(os.listdir(MODULES_PATH)):
+        if filename.endswith(".py") and filename != "__init__.py":
+            module_files.append(filename)
+    return module_files
+
+
+@pytest.mark.parametrize("module_file", get_module_files())
+def test_module_has_documentation_block(module_file):
+    """Every module MUST include a DOCUMENTATION block."""
+    filepath = os.path.join(MODULES_PATH, module_file)
+    with open(filepath, "r") as f:
+        content = f.read()
+    assert "DOCUMENTATION" in content, f"{module_file} is missing a DOCUMENTATION block"
+
+
+@pytest.mark.parametrize("module_file", get_module_files())
+def test_module_has_examples_block(module_file):
+    """Every module MUST include an EXAMPLES block."""
+    filepath = os.path.join(MODULES_PATH, module_file)
+    with open(filepath, "r") as f:
+        content = f.read()
+    assert "EXAMPLES" in content, f"{module_file} is missing an EXAMPLES block"
+
+
+@pytest.mark.parametrize("module_file", get_module_files())
+def test_module_has_return_block(module_file):
+    """Every module MUST include a RETURN block."""
+    filepath = os.path.join(MODULES_PATH, module_file)
+    with open(filepath, "r") as f:
+        content = f.read()
+    assert "RETURN" in content, f"{module_file} is missing a RETURN block"
+
+
+@pytest.mark.parametrize("module_file", get_module_files())
+def test_module_has_version_added(module_file):
+    """Every module MUST include a version_added field in DOCUMENTATION."""
+    filepath = os.path.join(MODULES_PATH, module_file)
+    with open(filepath, "r") as f:
+        content = f.read()
+    assert "version_added" in content, f"{module_file} is missing version_added in DOCUMENTATION"


### PR DESCRIPTION
## Changes

### Fix
- Added missing `RETURN` block to `plugins/modules/service.py` documenting the `services` dict and `msg` string return values

### Tests
- Added `tests/unit/modules/test_module_documentation.py` with parametrized tests across all modules to prevent future regressions:
  - `test_module_has_documentation_block` — validates DOCUMENTATION present
  - `test_module_has_examples_block` — validates EXAMPLES present
  - `test_module_has_return_block` — validates RETURN present
  - `test_module_has_version_added` — validates version_added present

### Context
Per the [Ansible collection requirements](https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html#documentation-requirements):
> All modules MUST include a RETURN block for modules and other plugins that return data.

This was the only module in the collection missing one. The return key is `services` (plural) — confirmed by tracing through `NautobotIpamModule.run()` and verified by integration tests.

Closes #709