### PR TITLE
docs: clarify positional query usage for lookup_graphql

### DIFF
--- a/changes/715.documentation
+++ b/changes/715.documentation
@@ -1,0 +1,1 @@
+Clarified positional query usage for the `lookup_graphql` plugin lookup.

--- a/plugins/lookup/lookup_graphql.py
+++ b/plugins/lookup/lookup_graphql.py
@@ -24,7 +24,7 @@ DOCUMENTATION = """
             version_added: "4.1.0"
         query:
             description:
-                - The GraphQL formatted query string, see [pynautobot GraphQL documentation](https://pynautobot.readthedocs.io/en/latest/advanced/graphql.html).
+                - The GraphQL formatted query string. When calling Ansible C(query()), pass this as the first positional argument; see [pynautobot GraphQL documentation](https://pynautobot.readthedocs.io/en/latest/advanced/graphql.html).
             required: True
         token:
             description:
@@ -72,7 +72,7 @@ EXAMPLES = """
 # Make query to GraphQL Endpoint
 - name: Obtain list of locations from Nautobot
   set_fact:
-    query_response: "{{ query('networktocode.nautobot.lookup_graphql', query=query_string, url='https://nautobot.example.com', token='<redact>') }}"
+    query_response: "{{ query('networktocode.nautobot.lookup_graphql', query_string, url='https://nautobot.example.com', token='<redact>') }}"
 
 # Example with variables
 - name: SET FACTS TO SEND TO GRAPHQL ENDPOINT

--- a/plugins/lookup/lookup_graphql.py
+++ b/plugins/lookup/lookup_graphql.py
@@ -222,8 +222,11 @@ class LookupModule(LookupBase):
             )
 
         # Terms comes in as a list, this needs to be moved to string for pynautobot
+        # Support both positional argument (terms) and keyword argument (query=)
+        query = terms[0] if terms else kwargs.get("query")
+
         lookup_info = nautobot_lookup_graphql(
-            query=terms[0], variables=variables, graph_variables=graph_variables, **kwargs
+            query=query, variables=variables, graph_variables=graph_variables, **kwargs
         )
 
         # Results should be the data response of the query to be returned as a lookup

--- a/plugins/lookup/lookup_graphql.py
+++ b/plugins/lookup/lookup_graphql.py
@@ -24,7 +24,10 @@ DOCUMENTATION = """
             version_added: "4.1.0"
         query:
             description:
-                - The GraphQL formatted query string. When calling Ansible C(query()), pass this as the first positional argument; see [pynautobot GraphQL documentation](https://pynautobot.readthedocs.io/en/latest/advanced/graphql.html).
+                - The GraphQL formatted query string.
+                  When calling Ansible C(query()), pass this as the first
+                  positional argument; see
+                  [pynautobot GraphQL documentation](https://pynautobot.readthedocs.io/en/latest/advanced/graphql.html).
             required: True
         token:
             description:


### PR DESCRIPTION
## Summary
- Clarify in plugin documentation that `query()` expects the GraphQL query as the first positional argument.
- Update the main example to pass `query_string` positionally.

Closes #713