### PR TITLE
Publish collection to Red Hat Automation Hub on release

### DIFF
--- a/.github/workflows/automationhub_token_keepalive.yml
+++ b/.github/workflows/automationhub_token_keepalive.yml
@@ -1,0 +1,23 @@
+---
+# Red Hat offline tokens expire after 30 days of inactivity. This workflow
+# refreshes the token twice a month so the next release can publish without
+# manual intervention. Manual workflow_dispatch is also available for
+# post-rotation validation.
+name: "AutomationHub Token Keepalive"
+on: # yamllint disable-line rule:truthy
+  schedule:
+    - cron: "0 0 1,15 * *"
+  workflow_dispatch:
+
+jobs:
+  refresh:
+    name: "Refresh Automation Hub offline token"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Refresh offline token"
+        run: |
+          curl "${{ secrets.AUTOMATION_HUB_SSO_URL }}" \
+            -d grant_type=refresh_token \
+            -d client_id=cloud-services \
+            -d refresh_token="${{ secrets.AUTOMATION_HUB_API_TOKEN }}" \
+            --fail --silent --show-error --output /dev/null

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -65,9 +65,9 @@ jobs:
         run: |
           cat << EOF > ansible.cfg
           [galaxy]
-          server_list = release_galaxy
-          [galaxy_server.release_galaxy]
-          url=https://galaxy.ansible.com/
+          server_list = published
+          [galaxy_server.published]
+          url=https://galaxy.ansible.com/api/
           token=${{ secrets.GALAXY_API_TOKEN }}
           EOF
         shell: bash

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -5,8 +5,8 @@ on: # yamllint disable
     types: [published]
 
 jobs:
-  publish_github:
-    name: "Publish to GitHub"
+  build_collection:
+    name: "Build Collection"
     runs-on: "ubuntu-latest"
     if: "startsWith(github.ref, 'refs/tags/v')"
     steps:
@@ -20,6 +20,22 @@ jobs:
         run: "pip install ansible-core"
       - name: "Build the collection"
         run: "ansible-galaxy collection build --output-path build"
+      - name: "Upload collection artifact"
+        uses: "actions/upload-artifact@v4"
+        with:
+          name: "collection"
+          path: "build/*.tar.gz"
+
+  publish_github:
+    name: "Publish to GitHub"
+    needs: "build_collection"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Download collection artifact"
+        uses: "actions/download-artifact@v4"
+        with:
+          name: "collection"
+          path: "build"
       - name: "Upload binaries to release"
         uses: "svenstaro/upload-release-action@v2"
         with:
@@ -28,30 +44,63 @@ jobs:
           tag: "${{ github.ref }}"
           overwrite: true
           file_glob: true
+
   publish_galaxy:
     name: "Publish to Ansible Galaxy"
+    needs: "build_collection"
     runs-on: "ubuntu-latest"
-    if: "startsWith(github.ref, 'refs/tags/v')"
     steps:
-      - name: "Check out repository code"
-        uses: "actions/checkout@v4"
       - name: "Set up Python"
         uses: "actions/setup-python@v5"
         with:
           python-version: "3.11"
       - name: "Install Python Packages"
         run: "pip install ansible-core"
+      - name: "Download collection artifact"
+        uses: "actions/download-artifact@v4"
+        with:
+          name: "collection"
+          path: "build"
       - name: "Create the ansible.cfg file"
         run: |
           cat << EOF > ansible.cfg
           [galaxy]
-          server_list = published
-          [galaxy_server.published]
-          url=https://galaxy.ansible.com/api/
+          server_list = release_galaxy
+          [galaxy_server.release_galaxy]
+          url=https://galaxy.ansible.com/
           token=${{ secrets.GALAXY_API_TOKEN }}
           EOF
         shell: bash
-      - name: "Build the collection"
-        run: "ansible-galaxy collection build --output-path build"
       - name: "Publish the collection"
-        run: "ansible-galaxy collection publish build/*"
+        run: "ansible-galaxy collection publish build/*.tar.gz"
+
+  publish_automation_hub:
+    name: "Publish to Red Hat Automation Hub"
+    needs: "build_collection"
+    runs-on: "ubuntu-latest"
+    continue-on-error: true
+    steps:
+      - name: "Set up Python"
+        uses: "actions/setup-python@v5"
+        with:
+          python-version: "3.11"
+      - name: "Install Python Packages"
+        run: "pip install ansible-core"
+      - name: "Download collection artifact"
+        uses: "actions/download-artifact@v4"
+        with:
+          name: "collection"
+          path: "build"
+      - name: "Create the ansible.cfg file"
+        run: |
+          cat << EOF > ansible.cfg
+          [galaxy]
+          server_list = automation_hub
+          [galaxy_server.automation_hub]
+          url=${{ secrets.AUTOMATION_HUB_URL }}
+          auth_url=${{ secrets.AUTOMATION_HUB_SSO_URL }}
+          token=${{ secrets.AUTOMATION_HUB_API_TOKEN }}
+          EOF
+        shell: bash
+      - name: "Publish the collection"
+        run: "ansible-galaxy collection publish build/*.tar.gz"

--- a/changes/734.housekeeping
+++ b/changes/734.housekeeping
@@ -1,0 +1,1 @@
+Added publishing of the collection to Red Hat Automation Hub alongside Ansible Galaxy.


### PR DESCRIPTION
## Summary

- Adds automated publishing of `networktocode.nautobot` to Red Hat Automation Hub on every tagged release, alongside the existing Ansible Galaxy publish.
- Refactors `trigger_release.yml` into a `build_collection` job feeding `publish_github`, `publish_galaxy`, and the new `publish_automation_hub` job, so the same artifact ships to all three destinations.
- Adds `automationhub_token_keepalive.yml` to refresh the Red Hat offline token on the 1st and 15th of each month, plus `workflow_dispatch` for manual validation after token rotation.

`publish_automation_hub` uses `continue-on-error: true` initially so a Hub-side issue cannot block a Galaxy release. This can be dropped after a few clean releases.

Pattern mirrors `PaloAltoNetworks/pan-os-ansible`.

Closes #734