### PR TITLE
Add range option to the `vlan_group` module

### DIFF
--- a/changes/738.added
+++ b/changes/738.added
@@ -1,0 +1,1 @@
+Added range option to the `vlan_group` module so that vlan ranges can be associated with vlan groups.

--- a/plugins/modules/vlan_group.py
+++ b/plugins/modules/vlan_group.py
@@ -48,7 +48,7 @@ options:
     description:
       - The range that will be assigned to the vlan group
     required: false
-    type: raw
+    type: str
     version_added: "6.3.0"
 """
 
@@ -124,7 +124,7 @@ def main():
             name=dict(required=False, type="str"),
             location=dict(required=False, type="raw"),
             description=dict(required=False, type="str"),
-            range=dict(required=False, type="raw"),
+            range=dict(required=False, type="str"),
         )
     )
 

--- a/plugins/modules/vlan_group.py
+++ b/plugins/modules/vlan_group.py
@@ -44,6 +44,12 @@ options:
     required: false
     type: str
     version_added: "3.0.0"
+  range:
+    description:
+      - The range that will be assigned to the vlan group
+    required: false
+    type: raw
+    version_added: "6.2.1"
 """
 
 EXAMPLES = r"""
@@ -61,6 +67,7 @@ EXAMPLES = r"""
         location:
           name: My Location
           parent: Parent Location
+        range: 1-40,200
         state: present
 
     - name: Delete vlan group within nautobot
@@ -117,6 +124,7 @@ def main():
             name=dict(required=False, type="str"),
             location=dict(required=False, type="raw"),
             description=dict(required=False, type="str"),
+            range=dict(required=False, type="raw"),
         )
     )
 

--- a/plugins/modules/vlan_group.py
+++ b/plugins/modules/vlan_group.py
@@ -49,7 +49,7 @@ options:
       - The range that will be assigned to the vlan group
     required: false
     type: raw
-    version_added: "6.2.1"
+    version_added: "6.3.0"
 """
 
 EXAMPLES = r"""

--- a/tests/integration/targets/latest/tasks/vlan_group.yml
+++ b/tests/integration/targets/latest/tasks/vlan_group.yml
@@ -150,7 +150,7 @@
     that:
       - not test_eight['changed']
       - test_eight['vlan_group']['range'] == "1-40,200"
-        - test_eight['msg'] == "vlan_group VLAN Group Range already exists"
+      - test_eight['msg'] == "vlan_group VLAN Group Range already exists"
 
 - name: "VLAN_GROUP 9: Update range on existing group"
   networktocode.nautobot.vlan_group:

--- a/tests/integration/targets/latest/tasks/vlan_group.yml
+++ b/tests/integration/targets/latest/tasks/vlan_group.yml
@@ -111,77 +111,77 @@
       - test_six['vlan_group'] == None
       - test_six['msg'] == "vlan_group VLAN Group One already absent"
 
-  - name: "VLAN_GROUP 7: Create with range"
-    networktocode.nautobot.vlan_group:
-      url: "{{ nautobot_url }}"
-      token: "{{ nautobot_token }}"
-      name: "VLAN Group Range"
-      location:
-        name: "Child Test Location"
-        parent: "Parent Test Location"
-      range: "1-40,200"
-      state: present
-    register: test_seven
+- name: "VLAN_GROUP 7: Create with range"
+  networktocode.nautobot.vlan_group:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    name: "VLAN Group Range"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
+    range: "1-40,200"
+    state: present
+  register: test_seven
 
-  - name: "VLAN_GROUP 7: ASSERT - Create with range"
-    assert:
-      that:
-        - test_seven is changed
-        - test_seven['diff']['before']['state'] == "absent"
-        - test_seven['diff']['after']['state'] == "present"
-        - test_seven['vlan_group']['name'] == "VLAN Group Range"
-        - test_seven['vlan_group']['range'] == "1-40,200"
-        - test_seven['msg'] == "vlan_group VLAN Group Range created"
+- name: "VLAN_GROUP 7: ASSERT - Create with range"
+  assert:
+    that:
+      - test_seven is changed
+      - test_seven['diff']['before']['state'] == "absent"
+      - test_seven['diff']['after']['state'] == "present"
+      - test_seven['vlan_group']['name'] == "VLAN Group Range"
+      - test_seven['vlan_group']['range'] == "1-40,200"
+      - test_seven['msg'] == "vlan_group VLAN Group Range created"
 
-  - name: "VLAN_GROUP 8: Create with range idempotent"
-    networktocode.nautobot.vlan_group:
-      url: "{{ nautobot_url }}"
-      token: "{{ nautobot_token }}"
-      name: "VLAN Group Range"
-      location:
-        name: "Child Test Location"
-        parent: "Parent Test Location"
-      range: "1-40,200"
-      state: present
-    register: test_eight
+- name: "VLAN_GROUP 8: Create with range idempotent"
+  networktocode.nautobot.vlan_group:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    name: "VLAN Group Range"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
+    range: "1-40,200"
+    state: present
+  register: test_eight
 
-  - name: "VLAN_GROUP 8: ASSERT - Create with range idempotent"
-    assert:
-      that:
-        - not test_eight['changed']
-        - test_eight['vlan_group']['range'] == "1-40,200"
+- name: "VLAN_GROUP 8: ASSERT - Create with range idempotent"
+  assert:
+    that:
+      - not test_eight['changed']
+      - test_eight['vlan_group']['range'] == "1-40,200"
         - test_eight['msg'] == "vlan_group VLAN Group Range already exists"
 
-  - name: "VLAN_GROUP 9: Update range on existing group"
-    networktocode.nautobot.vlan_group:
-      url: "{{ nautobot_url }}"
-      token: "{{ nautobot_token }}"
-      name: "VLAN Group Range"
-      location:
-        name: "Child Test Location"
-        parent: "Parent Test Location"
-      range: "1-100,500-600"
-      state: present
-    register: test_nine
+- name: "VLAN_GROUP 9: Update range on existing group"
+  networktocode.nautobot.vlan_group:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    name: "VLAN Group Range"
+    location:
+      name: "Child Test Location"
+      parent: "Parent Test Location"
+    range: "1-100,500-600"
+    state: present
+  register: test_nine
 
-  - name: "VLAN_GROUP 9: ASSERT - Update range on existing group"
-    assert:
-      that:
-        - test_nine is changed
-        - test_nine['diff']['after']['range'] == "1-100,500-600"
-        - test_nine['vlan_group']['range'] == "1-100,500-600"
-        - test_nine['msg'] == "vlan_group VLAN Group Range updated"
+- name: "VLAN_GROUP 9: ASSERT - Update range on existing group"
+  assert:
+    that:
+      - test_nine is changed
+      - test_nine['diff']['after']['range'] == "1-100,500-600"
+      - test_nine['vlan_group']['range'] == "1-100,500-600"
+      - test_nine['msg'] == "vlan_group VLAN Group Range updated"
 
-  - name: "VLAN_GROUP 10: Cleanup range group"
-    networktocode.nautobot.vlan_group:
-      url: "{{ nautobot_url }}"
-      token: "{{ nautobot_token }}"
-      name: "VLAN Group Range"
-      state: absent
-    register: test_ten
+- name: "VLAN_GROUP 10: Cleanup range group"
+  networktocode.nautobot.vlan_group:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    name: "VLAN Group Range"
+    state: absent
+  register: test_ten
 
-  - name: "VLAN_GROUP 10: ASSERT - Cleanup range group"
-    assert:
-      that:
-        - test_ten is changed
-        - test_ten['diff']['after']['state'] == "absent"
+- name: "VLAN_GROUP 10: ASSERT - Cleanup range group"
+  assert:
+    that:
+      - test_ten is changed
+      - test_ten['diff']['after']['state'] == "absent"

--- a/tests/integration/targets/latest/tasks/vlan_group.yml
+++ b/tests/integration/targets/latest/tasks/vlan_group.yml
@@ -110,3 +110,78 @@
       - not test_six['changed']
       - test_six['vlan_group'] == None
       - test_six['msg'] == "vlan_group VLAN Group One already absent"
+
+  - name: "VLAN_GROUP 7: Create with range"
+    networktocode.nautobot.vlan_group:
+      url: "{{ nautobot_url }}"
+      token: "{{ nautobot_token }}"
+      name: "VLAN Group Range"
+      location:
+        name: "Child Test Location"
+        parent: "Parent Test Location"
+      range: "1-40,200"
+      state: present
+    register: test_seven
+
+  - name: "VLAN_GROUP 7: ASSERT - Create with range"
+    assert:
+      that:
+        - test_seven is changed
+        - test_seven['diff']['before']['state'] == "absent"
+        - test_seven['diff']['after']['state'] == "present"
+        - test_seven['vlan_group']['name'] == "VLAN Group Range"
+        - test_seven['vlan_group']['range'] == "1-40,200"
+        - test_seven['msg'] == "vlan_group VLAN Group Range created"
+
+  - name: "VLAN_GROUP 8: Create with range idempotent"
+    networktocode.nautobot.vlan_group:
+      url: "{{ nautobot_url }}"
+      token: "{{ nautobot_token }}"
+      name: "VLAN Group Range"
+      location:
+        name: "Child Test Location"
+        parent: "Parent Test Location"
+      range: "1-40,200"
+      state: present
+    register: test_eight
+
+  - name: "VLAN_GROUP 8: ASSERT - Create with range idempotent"
+    assert:
+      that:
+        - not test_eight['changed']
+        - test_eight['vlan_group']['range'] == "1-40,200"
+        - test_eight['msg'] == "vlan_group VLAN Group Range already exists"
+
+  - name: "VLAN_GROUP 9: Update range on existing group"
+    networktocode.nautobot.vlan_group:
+      url: "{{ nautobot_url }}"
+      token: "{{ nautobot_token }}"
+      name: "VLAN Group Range"
+      location:
+        name: "Child Test Location"
+        parent: "Parent Test Location"
+      range: "1-100,500-600"
+      state: present
+    register: test_nine
+
+  - name: "VLAN_GROUP 9: ASSERT - Update range on existing group"
+    assert:
+      that:
+        - test_nine is changed
+        - test_nine['diff']['after']['range'] == "1-100,500-600"
+        - test_nine['vlan_group']['range'] == "1-100,500-600"
+        - test_nine['msg'] == "vlan_group VLAN Group Range updated"
+
+  - name: "VLAN_GROUP 10: Cleanup range group"
+    networktocode.nautobot.vlan_group:
+      url: "{{ nautobot_url }}"
+      token: "{{ nautobot_token }}"
+      name: "VLAN Group Range"
+      state: absent
+    register: test_ten
+
+  - name: "VLAN_GROUP 10: ASSERT - Cleanup range group"
+    assert:
+      that:
+        - test_ten is changed
+        - test_ten['diff']['after']['state'] == "absent"


### PR DESCRIPTION
Add the range option to the `vlan_group` module so that VLAN ranges may be associated with vlan groups.