### PR TITLE
Added Nautobot v3.1 tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,7 @@ jobs:
         python-version:
           - "3.12"
         nautobot-version:
-          - "3.0"
+          - "3.1"
         ansible-version:
           - "2.19"
     with:
@@ -103,6 +103,7 @@ jobs:
           - "3.13"
         nautobot-version:
           - "3.0"
+          - "3.1"
         ansible-version:
           - "2.18"
           - "2.19"

--- a/changes/729.added
+++ b/changes/729.added
@@ -1,0 +1,1 @@
+Added the `port_type` option to the `device_interface` module.

--- a/changes/729.housekeeping
+++ b/changes/729.housekeeping
@@ -1,0 +1,1 @@
+Added Nautobot v3.1 to the CI test matrix.

--- a/development/requirements.txt
+++ b/development/requirements.txt
@@ -1,1 +1,1 @@
-nautobot-bgp-models==3.0.0
+nautobot-bgp-models==3.1.0

--- a/plugins/modules/device_interface.py
+++ b/plugins/modules/device_interface.py
@@ -155,6 +155,12 @@ options:
     required: false
     type: raw
     version_added: "5.12.0"
+  port_type:
+    description:
+      - The type of port the interface is
+    required: false
+    type: str
+    version_added: "6.3.0"
   ip_addresses:
     description:
       - List of IP addresses to associate with this interface.
@@ -411,6 +417,7 @@ def main():
             untagged_vlan=dict(required=False, type="raw"),
             tagged_vlans=dict(required=False, type="raw"),
             vrf=dict(required=False, type="raw"),
+            port_type=dict(required=False, type="str"),
             ip_addresses=dict(
                 required=False,
                 type="dict",

--- a/tasks.py
+++ b/tasks.py
@@ -36,14 +36,14 @@ namespace.configure(
     {
         "nautobot_ansible": {
             "ansible_ver": "2.19",
-            "nautobot_ver": "3.0.0",
+            "nautobot_ver": "3.1",
             "project_name": "nautobot_ansible",
             "python_ver": "3.11",
             "local": False,
             "compose_dir": os.path.join(os.path.dirname(__file__), "development"),
             "compose_files": ["docker-compose.yml"],
             "min_inventory_test_ansible_version": "2.19",
-            "min_inventory_test_nautobot_version": "3.0",
+            "min_inventory_test_nautobot_version": "3.1",
         }
     }
 )

--- a/tests/integration/targets/inventory/files/inventory.json
+++ b/tests/integration/targets/inventory/files/inventory.json
@@ -219,6 +219,7 @@
                         "name": "GigabitEthernet1",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -414,6 +415,7 @@
                         "name": "Ethernet2/1",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -570,6 +572,7 @@
                         "name": "Ethernet1/1",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -1041,6 +1044,7 @@
                         "name": "GigabitEthernet1",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -1199,6 +1203,7 @@
                         "name": "GigabitEthernet2",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -1292,6 +1297,7 @@
                         "name": "GigabitEthernet3",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -1385,6 +1391,7 @@
                         "name": "GigabitEthernet4",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {

--- a/tests/integration/targets/inventory/files/inventory_modules.json
+++ b/tests/integration/targets/inventory/files/inventory_modules.json
@@ -345,6 +345,7 @@
                         "name": "GigabitEthernet1",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -611,6 +612,7 @@
                         "name": "Ethernet2/1",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -854,6 +856,7 @@
                         "name": "Ethernet1/1",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -1232,13 +1235,15 @@
                                 "comments": "",
                                 "custom_fields": {},
                                 "display": "Cisco C9300-NM-8X",
+                                "front_image": null,
                                 "manufacturer": {
                                     "object_type": "dcim.manufacturer"
                                 },
                                 "model": "C9300-NM-8X",
                                 "module_family": null,
                                 "object_type": "dcim.moduletype",
-                                "part_number": ""
+                                "part_number": "",
+                                "rear_image": null
                             },
                             "object_type": "dcim.module",
                             "parent_module_bay": {
@@ -1272,6 +1277,7 @@
                         "name": "Interface 1",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -1321,13 +1327,15 @@
                                 "comments": "",
                                 "custom_fields": {},
                                 "display": "Cisco C9300-NM-8X",
+                                "front_image": null,
                                 "manufacturer": {
                                     "object_type": "dcim.manufacturer"
                                 },
                                 "model": "C9300-NM-8X",
                                 "module_family": null,
                                 "object_type": "dcim.moduletype",
-                                "part_number": ""
+                                "part_number": "",
+                                "rear_image": null
                             },
                             "object_type": "dcim.module",
                             "parent_module_bay": {
@@ -1361,6 +1369,7 @@
                         "name": "Interface 1",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -1579,6 +1588,7 @@
                         "name": "GigabitEthernet1",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -1797,6 +1807,7 @@
                         "name": "GigabitEthernet2",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -1950,6 +1961,7 @@
                         "name": "GigabitEthernet3",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -2103,6 +2115,7 @@
                         "name": "GigabitEthernet4",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {

--- a/tests/integration/targets/inventory/files/inventory_options_flatten.json
+++ b/tests/integration/targets/inventory/files/inventory_options_flatten.json
@@ -211,6 +211,7 @@
                         "name": "GigabitEthernet1",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -405,6 +406,7 @@
                         "name": "Ethernet2/1",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -561,6 +563,7 @@
                         "name": "Ethernet1/1",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -1020,6 +1023,7 @@
                         "name": "GigabitEthernet1",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -1178,6 +1182,7 @@
                         "name": "GigabitEthernet2",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -1271,6 +1276,7 @@
                         "name": "GigabitEthernet3",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -1364,6 +1370,7 @@
                         "name": "GigabitEthernet4",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {

--- a/tests/integration/targets/inventory/files/inventory_plurals.json
+++ b/tests/integration/targets/inventory/files/inventory_plurals.json
@@ -250,6 +250,7 @@
                         "name": "GigabitEthernet1",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -457,6 +458,7 @@
                         "name": "Ethernet2/1",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -613,6 +615,7 @@
                         "name": "Ethernet1/1",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -1113,6 +1116,7 @@
                         "name": "GigabitEthernet1",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -1271,6 +1275,7 @@
                         "name": "GigabitEthernet2",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -1364,6 +1369,7 @@
                         "name": "GigabitEthernet3",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {
@@ -1457,6 +1463,7 @@
                         "name": "GigabitEthernet4",
                         "object_type": "dcim.interface",
                         "parent_interface": null,
+                        "port_type": null,
                         "role": null,
                         "speed": null,
                         "status": {

--- a/tests/integration/targets/inventory/files/inventory_plurals_flatten.json
+++ b/tests/integration/targets/inventory/files/inventory_plurals_flatten.json
@@ -447,11 +447,11 @@
             "child_child_test_location"
         ],
         "hosts": [
-            "R1-Device",
-            "test100",
-            "TestDeviceR1",
-            "Test Nexus One",
             "00000000-0000-0000-0000-000000000000",
+            "R1-Device",
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100",
             "test100-vm",
             "test101-vm",
             "test102-vm",
@@ -523,11 +523,11 @@
             "child_test_location"
         ],
         "hosts": [
-            "R1-Device",
-            "test100",
-            "TestDeviceR1",
-            "Test Nexus One",
             "00000000-0000-0000-0000-000000000000",
+            "R1-Device",
+            "Test Nexus One",
+            "TestDeviceR1",
+            "test100",
             "test100-vm",
             "test101-vm",
             "test102-vm",


### PR DESCRIPTION
Closes: #729

- Added Nautobot 3.1 to full integration test matrix
- Changed default version tested to 3.1 for PRs 
- Added new `port_type` field to the `device_interface` module (identified when running inventory tests)
- Updated minimum version to 3.1 for inventory tests