### PR TITLE
Minor fixes for `lookup_graphql`

### DIFF
--- a/changes/713.changed
+++ b/changes/713.changed
@@ -1,0 +1,1 @@
+Changed the `lookup_graphql` lookup to accept the query as either the first positional argument or as a keyword argument.

--- a/changes/714.documentation
+++ b/changes/714.documentation
@@ -1,0 +1,1 @@
+Changed the `lookup_graphql` examples to use `lookup()` instead of `query()` as the example return value is a dictionary instead of a list.

--- a/plugins/lookup/lookup_graphql.py
+++ b/plugins/lookup/lookup_graphql.py
@@ -25,6 +25,7 @@ DOCUMENTATION = """
         query:
             description:
                 - The GraphQL formatted query string, see [pynautobot GraphQL documentation](https://pynautobot.readthedocs.io/en/latest/advanced/graphql.html).
+                - Can be passed as the first positional argument or as a keyword argument.
             required: True
         token:
             description:
@@ -140,9 +141,6 @@ def nautobot_lookup_graphql(**kwargs):
     query = kwargs.get("query")
     Display().v("Query String: %s" % query)
 
-    # Check that a valid query was passed in
-    if query is None:
-        raise AnsibleLookupError("Query parameter was not passed. Please verify that query is passed.")
     # Setup API Token information, URL, and SSL verification
     url = kwargs.get("url") or os.getenv("NAUTOBOT_URL")
     Display().v("Nautobot URL: %s" % url)
@@ -218,9 +216,14 @@ class LookupModule(LookupBase):
                 PYNAUTOBOT_IMPORT_ERROR,
             )
 
+        query = terms[0] if terms else kwargs.get("query")
+        # Check that a valid query was passed in
+        if not query:
+            raise AnsibleLookupError("Query parameter was not passed. Please verify that query is passed.")
+
         # Terms comes in as a list, this needs to be moved to string for pynautobot
         lookup_info = nautobot_lookup_graphql(
-            query=terms[0], variables=variables, graph_variables=graph_variables, **kwargs
+            query=query, variables=variables, graph_variables=graph_variables, **kwargs
         )
 
         # Results should be the data response of the query to be returned as a lookup

--- a/plugins/lookup/lookup_graphql.py
+++ b/plugins/lookup/lookup_graphql.py
@@ -139,6 +139,10 @@ def nautobot_lookup_graphql(**kwargs):
     """
     # Add in logic on query to unpack
     query = kwargs.get("query")
+    # Check that a valid query was passed in
+    if not query:
+        raise AnsibleLookupError("Query parameter was not passed. Please verify that query is passed.")
+
     Display().v("Query String: %s" % query)
 
     # Setup API Token information, URL, and SSL verification
@@ -217,9 +221,6 @@ class LookupModule(LookupBase):
             )
 
         query = terms[0] if terms else kwargs.get("query")
-        # Check that a valid query was passed in
-        if not query:
-            raise AnsibleLookupError("Query parameter was not passed. Please verify that query is passed.")
 
         # Terms comes in as a list, this needs to be moved to string for pynautobot
         lookup_info = nautobot_lookup_graphql(

--- a/plugins/lookup/lookup_graphql.py
+++ b/plugins/lookup/lookup_graphql.py
@@ -73,7 +73,7 @@ EXAMPLES = """
 # Make query to GraphQL Endpoint
 - name: Obtain list of locations from Nautobot
   set_fact:
-    query_response: "{{ query('networktocode.nautobot.lookup_graphql', query=query_string, url='https://nautobot.example.com', token='<redact>') }}"
+    query_response: "{{ lookup('networktocode.nautobot.lookup_graphql', query=query_string, url='https://nautobot.example.com', token='<redact>') }}"
 
 # Example with variables
 - name: SET FACTS TO SEND TO GRAPHQL ENDPOINT
@@ -94,7 +94,7 @@ EXAMPLES = """
 # Get Response with variables
 - name: Obtain list of devices from Nautobot
   set_fact:
-    query_response: "{{ query('networktocode.nautobot.lookup_graphql', query_string, graph_variables=graph_variables,
+    query_response: "{{ lookup('networktocode.nautobot.lookup_graphql', query_string, graph_variables=graph_variables,
     url='https://nautobot.example.com', token='<redact>') }}"
 """
 

--- a/tests/unit/lookup/test_lookup_graphql.py
+++ b/tests/unit/lookup/test_lookup_graphql.py
@@ -16,7 +16,7 @@ except ImportError:
 
 def test_setup_api_error_missing_url():
     with pytest.raises(AnsibleLookupError) as exc:
-        test_class = nautobot_lookup_graphql(query="", token="abc123", validate_certs=False)
+        test_class = nautobot_lookup_graphql(query='{"ntc": "networktocode"}', token="abc123", validate_certs=False)
 
     assert str(exc.value) == "Missing URL of Nautobot"
 
@@ -24,7 +24,7 @@ def test_setup_api_error_missing_url():
 def test_setup_api_error_incorrect_validate_certs():
     with pytest.raises(AnsibleLookupError) as exc:
         test_class = nautobot_lookup_graphql(
-            query="",
+            query='{"ntc": "networktocode"}',
             url="https://nautobot.example.com",
             token="abc123",
             validate_certs="Hi",


### PR DESCRIPTION
Closes: #713

The `lookup_graphql` now accepts query as either the first positional argument or as a keyword argument.

Closes: #714

I updated the examples in the documentation to use `lookup()` instead of `query()` to match the documented return. Both will work, but `query()` returns a list of dictionaries instead of a single dictionary.