### PR TITLE
Suppress yamllint:unparsable-with-libyaml on inventory plugin EXAMPLES

### DIFF
--- a/changes/740.fixed
+++ b/changes/740.fixed
@@ -1,1 +1,0 @@
-Suppressed `yamllint:unparsable-with-libyaml` sanity check on inventory plugin EXAMPLES blocks.

--- a/changes/740.fixed
+++ b/changes/740.fixed
@@ -1,0 +1,1 @@
+Added an `ansible-test` sanity ignore for the `yamllint:unparsable-with-libyaml` rule on the `inventory` and `gql_inventory` plugin EXAMPLES blocks, matching the workaround used by `amazon.aws` for upstream ansible-test bug ansible/ansible#82353. This unblocks publication to automation-hub without altering the multi-document EXAMPLES content.

--- a/changes/740.fixed
+++ b/changes/740.fixed
@@ -1,1 +1,1 @@
-Added an `ansible-test` sanity ignore for the `yamllint:unparsable-with-libyaml` rule on the `inventory` and `gql_inventory` plugin EXAMPLES blocks, matching the workaround used by `amazon.aws` for upstream ansible-test bug ansible/ansible#82353. This unblocks publication to automation-hub without altering the multi-document EXAMPLES content.
+Suppressed `yamllint:unparsable-with-libyaml` sanity check on inventory plugin EXAMPLES blocks.

--- a/changes/740.housekeeping
+++ b/changes/740.housekeeping
@@ -1,0 +1,1 @@
+Added a sanity test ignore for the `inventory` and `gql_inventory` plugins to unblock publication to automation-hub.

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,0 +1,2 @@
+plugins/inventory/gql_inventory.py yamllint:unparsable-with-libyaml # bug in ansible-test - https://github.com/ansible/ansible/issues/82353
+plugins/inventory/inventory.py yamllint:unparsable-with-libyaml # bug in ansible-test - https://github.com/ansible/ansible/issues/82353


### PR DESCRIPTION
## Summary

- Adds `tests/sanity/ignore-2.16.txt` with narrow `yamllint:unparsable-with-libyaml` ignores for `plugins/inventory/inventory.py` and `plugins/inventory/gql_inventory.py`.
- Mirrors the workaround used by [`ansible-collections/amazon.aws`](https://github.com/ansible-collections/amazon.aws/blob/main/tests/sanity/ignore-2.16.txt) for the same upstream bug ([ansible/ansible#82353](https://github.com/ansible/ansible/issues/82353)).
- Closes #740.

## Why

The galaxy-importer step on automation-hub runs `ansible-test sanity` with ansible-core 2.16, whose yamllint rule rejects multi-document YAML inside `EXAMPLES` docstrings:

```
ERROR: plugins/inventory/gql_inventory.py:147:1: unparsable-with-libyaml: expected a single document in the stream - but found another document
ERROR: plugins/inventory/inventory.py:241:1: unparsable-with-libyaml: expected a single document in the stream - but found another document
```

Both inventory plugins intentionally use `---`-separated alternative configs to document plugin variants. This is the standard inventory-plugin pattern (used by `amazon.aws`, `community.docker`, `community.general/incus`, `community.general/lxd`, `hetzner.hcloud`).

Rather than restructuring the EXAMPLES docs and degrading the `ansible-doc` reading experience for users, this PR applies the same fix that `amazon.aws` applies for `aws_ec2.py`: a narrowly-scoped sanity ignore on just the two files for just the one rule, with a comment citing the upstream bug.

## Scope

Only `ignore-2.16.txt` is required. ansible-core 2.19 does not reproduce the failure (verified locally), and `amazon.aws` scopes their ignore identically to 2.16 only. If galaxy-importer ever bumps to a newer ansible-core that reintroduces the strictness, a matching ignore for that version can be added then.