### PR TITLE
Run galaxy-importer simulation on every PR

### DIFF
--- a/.github/workflows/galaxy_import.yml
+++ b/.github/workflows/galaxy_import.yml
@@ -2,6 +2,7 @@
 name: "Galaxy Importer Manual Test"
 on:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/galaxy_import.yml
+++ b/.github/workflows/galaxy_import.yml
@@ -1,5 +1,5 @@
 ---
-name: "Galaxy Importer Manual Test"
+name: "Galaxy Importer Test"
 on:
   workflow_dispatch:
   workflow_call:

--- a/.github/workflows/galaxy_import.yml
+++ b/.github/workflows/galaxy_import.yml
@@ -14,11 +14,59 @@ jobs:
     runs-on: "ubuntu-latest"
     needs:
       - build
+    env:
+      # Python 3.12 is a valid controller version for every ansible-core from
+      # 2.17 through 2.21, so it does not need to track the floor below.
+      PYTHON_VERSION: "3.12"
     steps:
+      # Checkout must come before download-artifact: actions/checkout cleans
+      # the workspace by default and would delete the downloaded tarball.
+      # The checkout exists only so we can read meta/runtime.yml.
+      - name: Check out repository code
+        uses: actions/checkout@v6
+
       - name: Download artifact
         uses: actions/download-artifact@v8
         with:
           name: ${{ needs.build.outputs.artifact-name }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "${{ env.PYTHON_VERSION }}"
+
+      # The importer runs `ansible-test sanity` against whichever ansible-core
+      # is installed. Run it at the oldest version this collection claims to
+      # support, so the check answers a question we actually care about:
+      # "does the collection still import cleanly at our declared floor?"
+      #
+      # The floor is read from meta/runtime.yml rather than duplicated here, so
+      # there is one source of truth and raising the floor needs no edit to
+      # this workflow. Deriving it is also the only safe option: pinning BELOW
+      # the declared floor makes the `ansible-doc` sanity test fail on
+      # "collection does not support Ansible version X.Y".
+      - name: Derive ansible-core floor from meta/runtime.yml
+        run: |
+          floor=$(sed -n 's/^requires_ansible:[[:space:]]*">=\([0-9]\{1,\}\.[0-9]\{1,\}\).*/\1/p' meta/runtime.yml)
+          if [ -z "$floor" ]; then
+            echo "::error::could not parse requires_ansible from meta/runtime.yml"
+            exit 1
+          fi
+          echo "Declared ansible-core floor: ${floor}"
+          echo "ANSIBLE_CORE_SPEC=~=${floor}.0" >> "$GITHUB_ENV"
+
+      # ansible-lint is deliberately NOT pinned. galaxy-importer constrains it
+      # itself, and automation-hub tracks whatever galaxy-importer ships, so
+      # installing the same unpinned set is closer to the real publish gate
+      # than any version we could guess.
+      - name: Install galaxy-importer toolchain
+        run: |
+          pip install --disable-pip-version-check \
+            "ansible-core${ANSIBLE_CORE_SPEC}" \
+            galaxy-importer
+
+      - name: Record resolved tool versions
+        run: pip list | grep -iE '^(ansible-core|ansible-lint|galaxy.importer) '
 
       - name: Create config file
         run: |
@@ -26,7 +74,51 @@ jobs:
           RUN_ANSIBLE_TEST = True" > galaxy-importer.cfg
 
       - name: Test import
-        uses: ansible-community/github-action-test-galaxy-import@main
-        with:
-          artifact-path: ${{ needs.build.outputs.artifact-filename }}
-          importer-config-path: galaxy-importer.cfg
+        env:
+          ARTIFACT_FILENAME: "${{ needs.build.outputs.artifact-filename }}"
+          GALAXY_IMPORTER_CONFIG: galaxy-importer.cfg
+        run: python -m galaxy_importer.main "$ARTIFACT_FILENAME" | tee import.log
+
+      - name: Gate on importer findings
+        run: |
+          # galaxy-importer exits 0 for lint and sanity findings -- it only
+          # fails on a fatal, unreadable artifact. It also invokes
+          # `ansible-test sanity --failure-ok`, so sanity failures do not
+          # propagate either. This step is what turns findings into a red
+          # check; without it the job can only ever report success.
+          #
+          # galaxy-importer passes `--color yes` to ansible-test, so the
+          # ERROR: lines it echoes through are wrapped in ANSI color escapes
+          # and do NOT literally start with "ERROR:". Strip the escapes before
+          # matching. This is also why the upstream community action's
+          # line.startswith('ERROR:') check never even annotated #740.
+          sed -r 's/\x1b\[[0-9;]*m//g' import.log > import-plain.log
+
+          # Two log levels carry real findings, and both must fail the job:
+          #   ERROR:   fatal import errors, plus the `ansible-test sanity`
+          #            output the importer echoes through.
+          #   WARNING: ansible-lint rule violations. Matching only ERROR:
+          #            would sail straight past the #739 class of finding.
+          #
+          # ALLOWLIST holds importer output that does not block publication.
+          # Keep it as tight as possible and comment every entry.
+          #   - "Ignore files skip ansible-test sanity tests": galaxy-importer
+          #     notices that tests/sanity/ignore-*.txt exists. It scans for
+          #     these regardless of the core version in use. Drop this entry
+          #     once tests/sanity/ignore-2.16.txt is removed.
+          ALLOWLIST='Ignore files skip ansible-test sanity tests'
+
+          grep -E '^(ERROR|WARNING):' import-plain.log | grep -vE "$ALLOWLIST" > findings.txt || true
+
+          if [ -s findings.txt ]; then
+            echo "::error::galaxy-importer reported findings that would block publication to automation-hub"
+            while IFS= read -r finding; do
+              echo "::error::${finding}"
+            done < findings.txt
+            echo
+            echo "These are the same checks console.redhat.com runs at publish time."
+            echo "Fix them here rather than after the release is tagged."
+            exit 1
+          fi
+
+          echo "galaxy-importer reported no publication-blocking findings."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,3 +115,8 @@ jobs:
       ansible-version: "${{ matrix.ansible-version }}"
     needs:
       - "unit"
+
+  galaxy_importer:
+    uses: ./.github/workflows/galaxy_import.yml
+    needs:
+      - "unit"

--- a/changes/742.housekeeping
+++ b/changes/742.housekeeping
@@ -1,0 +1,1 @@
+Wired the galaxy-importer simulation into PR CI to catch automation-hub publish blockers pre-merge.

--- a/changes/742.housekeeping
+++ b/changes/742.housekeeping
@@ -1,1 +1,1 @@
-Wired the galaxy-importer simulation into PR CI to catch automation-hub publish blockers pre-merge.
+Wired the galaxy-importer simulation into pull request CI so that findings which would block publication to automation-hub now fail the build.

--- a/docs/getting_started/contributing/testing_with_gha.md
+++ b/docs/getting_started/contributing/testing_with_gha.md
@@ -10,8 +10,29 @@ After you have commit your code and published your branch, you can run the manua
 
 ## Galaxy Importer Test
 
-The Galaxy Importer Manual Test workflow is designed to test the collection with the [Galaxy Importer](https://github.com/ansible/galaxy-importer) library. You can run this workflow manually by going to the [Actions](https://github.com/networktocode/nautobot-ansible/actions) page and selecting the `Galaxy Importer Manual Test` workflow. Next, click on the `Run workflow` button and select your branch.
+The Galaxy Importer workflow tests the collection with the [Galaxy Importer](https://github.com/ansible/galaxy-importer) library, which is the same tool Red Hat's automation-hub runs when a release is published. It runs automatically as the `galaxy_importer` job on every pull request, and can also be run on demand by going to the [Actions](https://github.com/networktocode/nautobot-ansible/actions) page, selecting the `Galaxy Importer Manual Test` workflow, clicking `Run workflow`, and selecting your branch.
+
+### Which versions the job runs against
+
+The job installs `ansible-core` at the **oldest version this collection claims to support** and leaves `ansible-lint` unpinned.
+
+The `ansible-core` version is derived at runtime from the `requires_ansible` floor in `meta/runtime.yml`, not hardcoded in the workflow. That keeps a single source of truth: raising the floor needs no change to the workflow, and the two can never drift. It also avoids a trap — pinning *below* the declared floor makes the `ansible-doc` sanity test fail on `collection does not support Ansible version X.Y`, which would leave the job permanently red for a reason unrelated to any real publish blocker.
+
+`ansible-lint` is deliberately **not** pinned. galaxy-importer constrains the version itself, and automation-hub tracks whatever galaxy-importer ships, so installing the same unpinned set is closer to the real publish gate than any version we could guess from an import log.
+
+This makes the check answer a question worth asking — *does the collection still import cleanly at our declared floor, under the importer's own lint profile?* — rather than trying to replicate a Red Hat toolchain we cannot observe. `invoke lint` and the `unit` job cover the newer end of the supported range; this job covers the oldest end plus the build-and-import round trip that nothing else exercises.
+
+### How failures are reported
 
 !!! warning
 
-    The Galaxy Importer library is not designed to fail (exit with a non-zero exit code) if it encounters any linting or testing errors so the CI will not fail either. You will need to check the logs to determine if there are any issues that need to be addressed.
+    The Galaxy Importer library is not designed to fail (exit with a non-zero exit code) when it encounters linting or testing errors, and it runs `ansible-test sanity` with `--failure-ok` internally. The workflow therefore inspects the importer log itself and fails the job on any finding, rather than relying on the importer's exit code.
+
+The job fails on both of the log levels that carry real findings:
+
+- `ERROR:` — fatal import errors, plus the `ansible-test sanity` output the importer echoes through. This is the level [#740](https://github.com/nautobot/nautobot-ansible/issues/740) surfaced at.
+- `WARNING:` — `ansible-lint` rule violations. This is the level [#739](https://github.com/nautobot/nautobot-ansible/issues/739) surfaced at, so warnings cannot be ignored. Matching only `ERROR:` would sail straight past the #739 class of finding.
+
+The gate strips ANSI color escapes from the log before matching. galaxy-importer invokes `ansible-test sanity` with `--color yes`, so the `ERROR:` lines it echoes through are wrapped in escape sequences and do not literally start with `ERROR:`. This is also why the upstream community action's `line.startswith('ERROR:')` check never even annotated #740.
+
+Because `WARNING:` is treated as a failure, the workflow keeps a small allowlist of importer output that does not block publication. Today that allowlist holds one entry: galaxy-importer's own notice that `tests/sanity/ignore-*.txt` exists. That check scans `tests/sanity/` regardless of the pinned core version, so the notice fires on every run as long as the repository ships any ignore file. If you add to the allowlist, keep it as narrow as possible and comment why the entry is safe — an over-broad allowlist turns this job back into the decorative check it used to be.


### PR DESCRIPTION
## Summary

- Wires the existing `galaxy_import.yml` workflow into the PR test pipeline so the combined check that automation-hub's galaxy-importer runs (ansible-lint + ansible-test sanity + EDA ruff/pylint) fires on every PR.
- Closes #742.

## Why

PRs #743 and #747 in this batch fix issues (#739, #740) that surfaced only after v6.2.0 was tagged and pushed to Galaxy — local CI didn't catch them because it doesn't run the same combined check the importer does. This PR closes that gap so the next #739/#740 fails the PR instead of failing the publish.

## What changes

Two minimal edits:

- `.github/workflows/galaxy_import.yml` — adds `workflow_call:` alongside the existing `workflow_dispatch:` so the workflow is reusable from other workflows. Manual dispatch still works.
- `.github/workflows/tests.yml` — adds a new `galaxy_importer:` job that invokes `galaxy_import.yml` via `uses:`, mirroring how `integration_partial` and `integration_full` invoke `integration_tests.yml`.

The check itself uses `ansible-community/github-action-test-galaxy-import@main` against a locally-built collection tarball. No credentials, no upload to Galaxy or automation-hub — it's a pure publish-readiness signal that runs the same lint/sanity rules locally.

## Scope (what this PR is NOT)

- Does not pin tool versions. The community action tracks whatever ansible-core / ansible-lint automation-hub itself uses. Can be revisited if version skew bites us in practice.
- Does not modify the existing publish workflow (`trigger_release.yml`). Real Galaxy uploads still go through the credentialed release path, unchanged.

## Verification path

Once this merges and develop has both this and #743/#747, the next PR that introduces something the importer would reject (e.g. a stray `requires_ansible` floor or a sanity-blocking docstring change) will fail the new `galaxy_importer` check, not the publish step.

---

# Revised approach (supersedes the sections above)

Everything above is the original proposal, kept for review context. **Two of its claims turned out to be wrong**, and the implementation changed substantially as a result. Where the two conflict, this section is authoritative.

## Corrections to the original description

1. **"This would have caught both #739 and #740" was false.** The first CI run on this branch (jobs `77960045327` / `77960104274`) ran against a tarball that still contained both bugs and reported **zero findings**. The community action defaults to `ansible-core-version: stable-2.18` and installs the latest galaxy-importer, so it ran ansible-core 2.18.17 + ansible-lint 26.4.0. Both #739 and #740 are version-skew findings that this toolchain does not reproduce.

2. **"Does not pin tool versions … can be revisited if version skew bites us in practice"** understated it. Version skew was not a hypothetical future risk — it was the root cause of both issues, and leaving it unpinned made the check decorative.

## What @joewesch's review comment exposed

> Do you care this will never report an actual failure?

Correct, and worse than stated. Three separate reasons the job could not gate:

1. **The importer does not fail.** `galaxy_importer.main` exits non-zero only on a fatally unreadable artifact. It also invokes `ansible-test sanity --failure-ok`, so sanity failures never propagate. The community action's final step only converts `ERROR:` lines into `::warning::` annotations.

2. **Findings arrive at two log levels.** galaxy-importer logs `ansible-lint` violations at `WARNING:` and only fatal errors at `ERROR:`. A `grep '^ERROR:'` gate sails straight past the #739 class of finding.

3. **`ansible-test` output is ANSI-colored.** galaxy-importer passes `--color yes`, so the `ERROR:` lines it echoes through arrive as `\x1b[31mERROR: ...` and do not literally start with `ERROR:`. This means the upstream action's `line.startswith('ERROR:')` check would not have annotated #740 either. My own first cut at the gate had this same bug; only running it against a real tarball caught it.

## What this PR now does

`.github/workflows/galaxy_import.yml` — the `test:` job no longer delegates to `ansible-community/github-action-test-galaxy-import`. It installs the importer toolchain itself, runs `python -m galaxy_importer.main` against the built tarball, and fails the job on any finding, matching **both** `ERROR:` and `WARNING:` after stripping ANSI escapes.

`.github/workflows/tests.yml` — unchanged from the original proposal; the `galaxy_importer:` job invoking this workflow is still correct.

### Versions: our declared floor, not a guess at automation-hub's

`ansible-core` is installed at the collection's own `requires_ansible` floor, **read from `meta/runtime.yml` at runtime** rather than hardcoded. One source of truth, no constant that can drift, and no workflow edit needed when the floor moves. `ansible-lint` is left unpinned, since galaxy-importer constrains it and automation-hub tracks whatever galaxy-importer ships.

An intermediate revision did hardcode pins guessed from the v6.2.0 import log (ansible-core 2.16/2.17, ansible-lint 24.12.2). That was dropped for two reasons: those versions are **end of life** (2.16 since Jul 2025, 2.17 since Nov 2025), and pinning *below* the declared floor makes the `ansible-doc` sanity test fail on `collection does not support Ansible version X.Y` — which would have left the job permanently red for a reason unrelated to any real publish blocker.

The check now answers a question we own: *does the collection still import cleanly at our declared floor, under the importer's own lint profile?* If automation-hub turns out to run older than our floor, that is a support-matrix conversation rather than something to absorb into CI.

## Verification

Run locally against a real built tarball, including full `ansible-test sanity --docker`:

| scenario | expected | result |
|---|---|---|
| current `develop` | pass | pass — 34 sanity tests, only the allowlisted ignore-file notice |
| `requires_ansible` reverted to `>=2.18.0` (reintroduces #739) | fail | fail — reports `meta-runtime[unsupported-version]` |
| `tests/sanity/ignore-2.16.txt` removed (reintroduces #740) | fail | fail — reports both `unparsable-with-libyaml` errors |

The gate script was additionally exercised against every captured importer log on `ubuntu:24.04`, to confirm the ANSI handling and allowlist behave under GNU sed. `meta/runtime.yml` and the ignore file were restored after each positive control.

## Allowlist

Because `WARNING:` fails the job, the gate carries exactly one allowlist entry: galaxy-importer's informational notice that `tests/sanity/ignore-*.txt` exists. That check scans `tests/sanity/` regardless of the core version in use, so it fires on every run while the repo ships any ignore file. It can be dropped once that file is removed — see below.

## Follow-up, deliberately not in this PR

Working through the pins surfaced that this repo asserts an `ansible-core` support floor in four places that disagree, three of them naming end-of-life versions:

- `meta/runtime.yml` — `>=2.17.0` (EOL Nov 2025)
- `README.md` — "Ansible 2.18+" (EOL May 2026)
- `pyproject.toml` — `>=2.18,<2.21` (floor EOL; ceiling excludes maintained 2.21)
- CI matrix — tests 2.18, 2.19, 2.20; never tests 2.21

Note that #739 was fixed by *lowering* `meta/runtime.yml` from `>=2.18.0` to `>=2.17.0`, which pushed the declared floor further into EOL territory and desynchronised it from the README and `pyproject.toml`. Worth revisiting rather than preserving. A separate issue will propose `>=2.19.0`: the oldest currently maintained ansible-core, and also the highest floor our own `ansible-lint` accepts (`>=2.20.0` trips `meta-runtime` on ansible-lint 26.4.0). Raising the floor is user-visible, so it does not belong in a CI-plumbing PR.

Separately, #742's description should drop the EDA ruff/pylint bullet — galaxy-importer only runs EDA checks for collections shipping `extensions/eda`, which this one does not.
